### PR TITLE
fix: define db-data volume for overrides

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -32,3 +32,6 @@ services:
   storage:
     ports:
       - "4443:4443"
+
+volumes:
+  db-data:


### PR DESCRIPTION
## Summary
- add a top-level volumes section to docker-compose.override.yml so the db-data named volume is declared

## Testing
- not run (docker CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68d79b249abc8323b2fe6f5270b46bc4