### PR TITLE
Fix docker volume declaration in override compose file

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -18,7 +18,9 @@ services:
     ports:
       - "5432:5432"
     volumes:
-      - db-data:/var/lib/postgresql/data
+      - type: volume
+        source: db-data
+        target: /var/lib/postgresql/data
 
   redis:
     ports:
@@ -35,3 +37,4 @@ services:
 
 volumes:
   db-data:
+    driver: local


### PR DESCRIPTION
## Summary
- switch the Postgres override volume to the structured mapping format
- declare the named volume with an explicit local driver to avoid compose parser errors

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d79e7ea8f483239d091df3094a9d8d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Standardized database persistence by replacing the inline mapping with a named volume (db-data) targeting /var/lib/postgresql/data.
  - Explicitly sets the volume driver to local for clearer, consistent configuration.
  - No changes to other services or runtime behavior; improves portability, reduces potential permission issues, and simplifies environment setup and cleanup for local development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->