### PR TITLE
fix: use bind mount for postgres data in compose override

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -18,7 +18,7 @@ services:
     ports:
       - "5432:5432"
     volumes:
-      - db-data:/var/lib/postgresql/data
+      - ./storage/db-data:/var/lib/postgresql/data
 
   redis:
     ports:
@@ -33,5 +33,3 @@ services:
     ports:
       - "4443:4443"
 
-volumes:
-  db-data:


### PR DESCRIPTION
## Summary
- replace the named volume declaration in docker-compose.override.yml with a bind mount
- remove the unsupported top-level volume block to resolve docker compose parsing errors

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d79e7ea8f483239d091df3094a9d8d