### PR TITLE
fix: allow overriding docker postgres host port

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,7 @@ BACKEND_PORT=3000
 
 DB_HOST=db
 DB_PORT=5432
+DB_HOST_PORT=5432
 DB_USER=postgres
 DB_PASS=postgres
 DB_NAME=pokerhub

--- a/backend/src/config/database.config.ts
+++ b/backend/src/config/database.config.ts
@@ -1,8 +1,12 @@
 import { registerAs } from '@nestjs/config';
 
-export default registerAs('database', () => ({
-  url:
-    process.env.DATABASE_URL ??
-    'postgres://postgres:postgres@localhost:5432/pokerhub',
-  synchronize: process.env.DB_SYNC === 'true',
-}));
+export default registerAs('database', () => {
+  const localPort = process.env.DB_HOST_PORT ?? process.env.DB_PORT ?? '5432';
+
+  return {
+    url:
+      process.env.DATABASE_URL ??
+      `postgres://postgres:postgres@localhost:${localPort}/pokerhub`,
+    synchronize: process.env.DB_SYNC === 'true',
+  };
+});

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -16,7 +16,7 @@ services:
 
   db:
     ports:
-      - "5432:5432"
+      - "${DB_HOST_PORT:-5432}:5432"
     volumes:
       - ./storage/db-data:/var/lib/postgresql/data
 


### PR DESCRIPTION
## Summary
- introduce a DB_HOST_PORT variable to control the Postgres host binding
- update the backend default connection string to honor the host port override

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d7a19c023083239ed3484a6182ac47