### PR TITLE
fix: avoid postgres port collision with local installs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,9 @@ BACKEND_PORT=3000
 
 DB_HOST=db
 DB_PORT=5432
-DB_HOST_PORT=5432
+# Expose Postgres on a non-standard host port to avoid clashing with
+# developers' existing local installations. Change this if 15432 is taken.
+DB_HOST_PORT=15432
 DB_USER=postgres
 DB_PASS=postgres
 DB_NAME=pokerhub

--- a/README.md
+++ b/README.md
@@ -45,11 +45,16 @@ If you prefer to perform the steps manually:
 
    The `.env` file uses URL-style connection strings:
 
-   ```
+    ```
     DATABASE_URL=postgres://postgres:postgres@db:5432/pokerhub
     REDIS_URL=redis://redis:6379
     RABBITMQ_URL=amqp://guest:guest@rabbitmq:5672
     ```
+
+    By default the PostgreSQL container publishes on host port `15432` so it
+    does not collide with an existing local Postgres running on `5432`. Adjust
+    the `DB_HOST_PORT` value in `.env` if another process is already using
+    `15432`.
 
     Additional environment variables configure Google Cloud Storage:
 

--- a/backend/src/config/database.config.ts
+++ b/backend/src/config/database.config.ts
@@ -1,7 +1,7 @@
 import { registerAs } from '@nestjs/config';
 
 export default registerAs('database', () => {
-  const localPort = process.env.DB_HOST_PORT ?? process.env.DB_PORT ?? '5432';
+  const localPort = process.env.DB_HOST_PORT ?? process.env.DB_PORT ?? '15432';
 
   return {
     url:

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -16,7 +16,7 @@ services:
 
   db:
     ports:
-      - "${DB_HOST_PORT:-5432}:5432"
+      - "${DB_HOST_PORT:-15432}:5432"
     volumes:
       - ./storage/db-data:/var/lib/postgresql/data
 


### PR DESCRIPTION
## Summary
- change the docker compose override to publish postgres on host port 15432 by default
- update the environment template and database config fallback to honor the new default
- document the new host port guidance in the README so developers know how to override it

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d7a330ee34832399333e5e4e2915be