### PR TITLE
fix(infra): wrap postgres image for docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,9 @@ services:
         condition: service_healthy
 
   db:
-    image: postgres:15
+    build:
+      context: ./infra/db
+    image: pokerhub-db
     environment:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=postgres

--- a/infra/db/Dockerfile
+++ b/infra/db/Dockerfile
@@ -1,0 +1,6 @@
+# syntax=docker/dockerfile:1
+FROM postgres:15
+
+# A minimal wrapper image to work around docker-compose 1.x expecting
+# legacy image metadata fields (ContainerConfig) which are missing from
+# some upstream images when used directly.


### PR DESCRIPTION
## Summary
- wrap the Postgres service in a local image to restore compatibility with docker-compose 1.x
- update the compose definition to build and use the new image

## Testing
- not run (infrastructure change only)


------
https://chatgpt.com/codex/tasks/task_e_68d7a465d43c8323bcbafd91f9a140fc