### PR TITLE
fix: set default backend port for docker-compose override

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -2,7 +2,7 @@ version: '3.8'
 services:
   backend:
     ports:
-      - "${BACKEND_PORT}:3000"
+      - "${BACKEND_PORT:-3000}:3000"
     volumes:
       - ./backend:/app
     environment:


### PR DESCRIPTION
## Summary
- provide a default host port mapping for the backend service so docker-compose works when BACKEND_PORT is unset

## Testing
- ⚠️ `docker-compose config` *(not available in container)*
- ⚠️ `docker compose config` *(docker is not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d7aaa4f344832392a70f045fe2f8e5