### PR TITLE
fix: require docker compose plugin for local setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ and execute the test suite:
 ./scripts/quickstart.sh
 ```
 
-The script verifies required dependencies (`docker-compose` and `npm`), copies
+The script verifies required dependencies (`docker compose` and `npm`), copies
 `.env.example` to `.env` if needed, starts the containers, and runs `npm test`.
 
 If you prefer to perform the steps manually:
@@ -83,7 +83,7 @@ If you prefer to perform the steps manually:
 2. Start all services:
 
    ```bash
-   docker-compose up
+   docker compose up
    ```
 
    Override values in `.env` or extend `docker-compose.override.yml` for local tweaks.

--- a/load/README.md
+++ b/load/README.md
@@ -24,7 +24,13 @@ nightly and uploads the `load/metrics/latest` contents as artifacts.
 
 ## Local endpoints
 
-Ensure the following services are running (see `docker-compose.test.yml`):
+Ensure the following services are running (see `docker-compose.test.yml`). You can start them with:
+
+```sh
+docker compose -f docker-compose.yml -f docker-compose.test.yml up -d
+```
+
+Services expected:
 
 - Redis: `localhost:6379`
 - Backend API: `http://localhost:4000`

--- a/scripts/quickstart.sh
+++ b/scripts/quickstart.sh
@@ -15,8 +15,12 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$SCRIPT_DIR/.."
 cd "$ROOT_DIR"
 
-require_cmd docker-compose
+require_cmd docker
 require_cmd npm
+
+if ! docker compose version >/dev/null 2>&1; then
+  error "docker compose plugin is required but not installed."
+fi
 
 if [ ! -f .env ]; then
   if [ -f .env.example ]; then
@@ -30,7 +34,7 @@ else
 fi
 
 echo "Starting Docker services..."
-docker-compose up -d || error "docker-compose up failed"
+docker compose up -d || error "docker compose up failed"
 
 echo "Running tests..."
 npm test || error "npm test failed"


### PR DESCRIPTION
## Summary
- update the quickstart script to check for the Docker Compose v2 plugin and use `docker compose`
- refresh documentation to reference `docker compose` commands and add local startup snippet for load tests

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7ab910ff083239be9c05a87586836