### PR TITLE
fix: wrap docker infra images for docker-compose 1.x

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,8 @@
 version: '3.8'
 services:
   api-gateway:
-    image: kong:3.7
+    build: ./infra/api-gateway
+    image: pokerhub-kong
     environment:
       KONG_DATABASE: "off"
       KONG_DECLARATIVE_CONFIG: /usr/local/kong/declarative/kong.yml
@@ -49,7 +50,8 @@ services:
       retries: 5
 
   redis:
-    image: redis:7
+    build: ./infra/redis
+    image: pokerhub-redis
     healthcheck:
       test: ['CMD', 'redis-cli', 'ping']
       interval: 5s
@@ -57,7 +59,8 @@ services:
       retries: 5
 
   rabbitmq:
-    image: rabbitmq:3-management
+    build: ./infra/rabbitmq
+    image: pokerhub-rabbitmq
     environment:
       - RABBITMQ_DEFAULT_USER=guest
       - RABBITMQ_DEFAULT_PASS=guest
@@ -67,7 +70,8 @@ services:
       timeout: 5s
       retries: 5
   storage:
-    image: fsouza/fake-gcs-server:latest
+    build: ./infra/storage
+    image: pokerhub-fake-gcs
     command: -scheme http -backend memory
     ports:
       - '4443:4443'

--- a/infra/api-gateway/Dockerfile
+++ b/infra/api-gateway/Dockerfile
@@ -1,0 +1,5 @@
+# syntax=docker/dockerfile:1
+FROM kong:3.7
+
+# Wrapper image to restore legacy metadata fields (ContainerConfig) that
+# docker-compose 1.x still expects when inspecting upstream images.

--- a/infra/rabbitmq/Dockerfile
+++ b/infra/rabbitmq/Dockerfile
@@ -1,0 +1,4 @@
+# syntax=docker/dockerfile:1
+FROM rabbitmq:3-management
+
+# Wrapper image to expose legacy ContainerConfig metadata for docker-compose 1.x.

--- a/infra/redis/Dockerfile
+++ b/infra/redis/Dockerfile
@@ -1,0 +1,5 @@
+# syntax=docker/dockerfile:1
+FROM redis:7
+
+# Wrapper image to make docker-compose 1.x happy with missing ContainerConfig
+# metadata in some upstream images.

--- a/infra/storage/Dockerfile
+++ b/infra/storage/Dockerfile
@@ -1,0 +1,5 @@
+# syntax=docker/dockerfile:1
+FROM fsouza/fake-gcs-server:latest
+
+# Wrapper image for docker-compose 1.x compatibility (expects ContainerConfig
+# metadata in image inspect responses).


### PR DESCRIPTION
## Summary
- add lightweight wrapper Dockerfiles for Kong, Redis, RabbitMQ, and the fake GCS server
- update docker-compose to build from the wrappers so docker-compose 1.x sees ContainerConfig metadata again

## Testing
- Not run (docker not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68d7ab910ff083239be9c05a87586836