### PR TITLE
fix(infra): wrap fake GCS server image for docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,7 +67,8 @@ services:
       timeout: 5s
       retries: 5
   storage:
-    image: fsouza/fake-gcs-server:latest
+    build: ./infra/storage
+    image: pokerhub/fake-gcs-server:dev
     command: -scheme http -backend memory
     ports:
       - '4443:4443'

--- a/infra/storage/Dockerfile
+++ b/infra/storage/Dockerfile
@@ -1,0 +1,4 @@
+# syntax=docker/dockerfile:1
+FROM fsouza/fake-gcs-server:1.47.5
+
+LABEL org.opencontainers.image.source="https://github.com/Nera26/pokerhub"


### PR DESCRIPTION
## Summary
- add a local Dockerfile for the fake GCS storage emulator so docker-compose v1 can inspect it without hitting the ContainerConfig bug
- update the storage service to build from the local image and pin the emulator version

## Testing
- not run (docker not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68d7ab910ff083239be9c05a87586836