### PR TITLE
fix: wrap scratch-based images for docker-compose

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -22,7 +22,9 @@ services:
         condition: service_healthy
 
   load:
-    image: grafana/k6
+    build:
+      context: ./infra/load
+    image: pokerhub-load
     working_dir: /scripts
     volumes:
       - ./load:/scripts

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,7 +67,9 @@ services:
       timeout: 5s
       retries: 5
   storage:
-    image: fsouza/fake-gcs-server:latest
+    build:
+      context: ./infra/storage
+    image: pokerhub-storage
     command: -scheme http -backend memory
     ports:
       - '4443:4443'

--- a/infra/load/Dockerfile
+++ b/infra/load/Dockerfile
@@ -1,0 +1,7 @@
+# syntax=docker/dockerfile:1
+FROM grafana/k6:0.48.0
+
+# Compose 1.x requires a populated ContainerConfig. Adding a no-op label forces
+# the builder to emit a legacy-compatible image config so volume recreation does
+# not explode when the load-testing service is started.
+LABEL org.opencontainers.image.source="pokerhub"

--- a/infra/storage/Dockerfile
+++ b/infra/storage/Dockerfile
@@ -1,0 +1,9 @@
+# syntax=docker/dockerfile:1
+FROM fsouza/fake-gcs-server:1.52.0
+
+# docker-compose 1.x expects the legacy `ContainerConfig` metadata field to be
+# present on the image. Some upstream images (including fake-gcs-server) omit it
+# which triggers a KeyError inside docker-compose when recreating services. By
+# adding any instruction here (a harmless label) we force BuildKit to create a
+# new image config that contains the expected field.
+LABEL org.opencontainers.image.source="pokerhub"


### PR DESCRIPTION
## Summary
- add wrapper Dockerfiles for fake-gcs-server and k6 so docker-compose 1.x receives the legacy ContainerConfig metadata
- update docker-compose manifests to build those wrappers to prevent KeyError when recreating services

## Testing
- not run (docker is unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68d7ab910ff083239be9c05a87586836