### PR TITLE
fix: stabilize fake GCS storage healthcheck

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,4 +1,3 @@
-version: '3.8'
 services:
   backend:
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   api-gateway:
     build: ./infra/api-gateway
@@ -75,11 +73,12 @@ services:
   storage:
     build: ./infra/storage
     image: pokerhub-fake-gcs
-    command: -scheme http -backend memory
+    command: -scheme http -backend memory -port 4443
     ports:
       - '4443:4443'
     healthcheck:
-      test: ['CMD', 'curl', '-f', 'http://localhost:4443/storage/v1/b']
+      test: ['CMD-SHELL', 'curl -fsS http://localhost:4443/storage/v1/b >/dev/null']
       interval: 5s
       timeout: 5s
       retries: 5
+      start_period: 5s

--- a/infra/storage/Dockerfile
+++ b/infra/storage/Dockerfile
@@ -1,7 +1,14 @@
 # syntax=docker/dockerfile:1
-FROM fsouza/fake-gcs-server:1.52.0
 
-# Wrapper image for docker-compose compatibility.
-# docker-compose.yml passes runtime flags (e.g., "-scheme http -backend memory").
-# Adding a label forces a new image config so older docker-compose won't KeyError on ContainerConfig.
-LABEL org.opencontainers.image.source="https://github.com/Nera26/pokerhub"
+# 1) Pull the upstream binary
+FROM fsouza/fake-gcs-server:1.52.0 as upstream
+
+# 2) Small runtime with curl for healthcheck
+FROM alpine:3.20
+RUN apk add --no-cache ca-certificates curl
+
+# Copy the server binary from the upstream image
+COPY --from=upstream /fake-gcs-server /usr/local/bin/fake-gcs-server
+
+EXPOSE 4443
+ENTRYPOINT ["/usr/local/bin/fake-gcs-server"]


### PR DESCRIPTION
## Summary
- wrap the fake GCS server image with an Alpine layer that includes curl for healthchecks
- update the storage service command and healthcheck to use the new wrapper image and explicit port
- remove deprecated version declarations from docker compose files

## Testing
- not run (docker CLI unavailable in environment)


------
https://chatgpt.com/codex/tasks/task_e_68d7b23c8d5083238a73114b13c7f9be