### PR TITLE
fix: ensure fake gcs storage healthcheck succeeds

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -77,7 +77,7 @@ services:
     ports:
       - '4443:4443'
     healthcheck:
-      test: ['CMD-SHELL', 'curl -fsS http://localhost:4443/storage/v1/b >/dev/null']
+      test: ['CMD-SHELL', 'curl -fsS "http://localhost:4443/storage/v1/b?project=test" >/dev/null']
       interval: 5s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
## Summary
- update the fake GCS storage healthcheck to include the required project query parameter

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d7b3156ad4832388efd43b5c280b36