### PR TITLE
chore: update storage healthcheck endpoint

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -77,7 +77,7 @@ services:
     ports:
       - '4443:4443'
     healthcheck:
-      test: ['CMD-SHELL', 'curl -fsS "http://localhost:4443/storage/v1/b?project=test" >/dev/null']
+      test: ['CMD-SHELL', 'curl -fsS "http://localhost:4443/_internal/healthcheck" >/dev/null']
       interval: 5s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
## Summary
- update the storage service healthcheck to target the internal health endpoint

## Testing
- docker compose up -d storage *(fails: docker command not found in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d7b4d1fd40832389ab52337e12aa50