### PR TITLE
fix: restore fake GCS healthcheck endpoint

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -77,7 +77,7 @@ services:
     ports:
       - '4443:4443'
     healthcheck:
-      test: ['CMD-SHELL', 'curl -fsS "http://localhost:4443/_internal/healthcheck" >/dev/null']
+      test: ['CMD-SHELL', 'curl -fsS "http://localhost:4443/storage/v1/b?project=test" >/dev/null']
       interval: 5s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
## Summary
- update the storage service healthcheck to use the bucket listing probe expected by the emulator

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7b5e1360483238be391bb659719a5