### PR TITLE
fix: copy fake-gcs-server binary from upstream bin path

### DIFF
--- a/infra/storage/Dockerfile
+++ b/infra/storage/Dockerfile
@@ -8,7 +8,7 @@ FROM alpine:3.20
 RUN apk add --no-cache ca-certificates curl
 
 # Copy the server binary from the upstream image
-COPY --from=upstream /fake-gcs-server /usr/local/bin/fake-gcs-server
+COPY --from=upstream /bin/fake-gcs-server /usr/local/bin/fake-gcs-server
 
 EXPOSE 4443
 ENTRYPOINT ["/usr/local/bin/fake-gcs-server"]


### PR DESCRIPTION
## Summary
- update the storage Dockerfile to copy the fake-gcs-server binary from the upstream image's /bin directory

## Testing
- not run (docker is unavailable in the agent environment)


------
https://chatgpt.com/codex/tasks/task_e_68d7b70f48288323bc53ab9340a85ed1