### PR TITLE
chore(backend): align cache manager and redis usage

### DIFF
--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -78,8 +78,7 @@ export class AuthService {
     await this.redis.set(
       `${this.revokedPrefix}${refreshToken}`,
       '1',
-      'EX',
-      ttl,
+      { EX: ttl },
     );
     return rotated;
   }
@@ -89,8 +88,7 @@ export class AuthService {
     await this.redis.set(
       `${this.revokedPrefix}${refreshToken}`,
       '1',
-      'EX',
-      ttl,
+      { EX: ttl },
     );
     await this.sessions.revoke(refreshToken);
   }
@@ -121,7 +119,7 @@ export class AuthService {
     const code = randomInt(100000, 1000000).toString();
     const ttl = this.config.get<number>('auth.resetTtl', 900);
     const hash = this.hashCode(code);
-    await this.redis.set(`${this.resetPrefix}${email}`, hash, 'EX', ttl);
+    await this.redis.set(`${this.resetPrefix}${email}`, hash, { EX: ttl });
     await this.email.sendResetCode(email, code);
   }
 

--- a/backend/src/common/kyc.service.ts
+++ b/backend/src/common/kyc.service.ts
@@ -301,13 +301,13 @@ export class KycService implements OnModuleInit {
     const denialKey = `kyc:denial:${account.id}`;
     const regionReason = this.getRegionBlockReason(account);
     if (regionReason && this.cache) {
-      await this.cache.set(denialKey, regionReason, { ttl: 86400 });
+      await this.cache.set(denialKey, regionReason, 86400);
       throw new Error(regionReason);
     }
     if (ip) {
       const geoReason = await this.checkGeoIp(ip);
       if (geoReason && this.cache) {
-        await this.cache.set(denialKey, geoReason, { ttl: 86400 });
+        await this.cache.set(denialKey, geoReason, 86400);
         throw new Error(geoReason);
       }
     }
@@ -321,7 +321,7 @@ export class KycService implements OnModuleInit {
       'sanctions',
     );
     if (sanctionReason && this.cache) {
-      await this.cache.set(denialKey, sanctionReason, { ttl: 86400 });
+      await this.cache.set(denialKey, sanctionReason, 86400);
       throw new Error(sanctionReason);
     }
 
@@ -331,7 +331,7 @@ export class KycService implements OnModuleInit {
       'pep',
     );
     if (pepReason && this.cache) {
-      await this.cache.set(denialKey, pepReason, { ttl: 86400 });
+      await this.cache.set(denialKey, pepReason, 86400);
       throw new Error(pepReason);
     }
 
@@ -340,7 +340,7 @@ export class KycService implements OnModuleInit {
     if (!result) {
       result = await this.callProvider(account);
       if (this.cache) {
-        await this.cache.set(key, result, { ttl: 3600 });
+        await this.cache.set(key, result, 3600);
       }
     }
 
@@ -354,7 +354,7 @@ export class KycService implements OnModuleInit {
     } else {
       const reason = result.reason ?? 'KYC verification failed';
       if (this.cache) {
-        await this.cache.set(denialKey, reason, { ttl: 86400 });
+        await this.cache.set(denialKey, reason, 86400);
       }
       throw new Error(reason);
     }

--- a/backend/src/leaderboard/leaderboard.service.ts
+++ b/backend/src/leaderboard/leaderboard.service.ts
@@ -1,4 +1,5 @@
-import { CACHE_MANAGER, Inject, Injectable, OnModuleInit } from '@nestjs/common';
+import { Inject, Injectable, OnModuleInit } from '@nestjs/common';
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
 import { Cache } from 'cache-manager';
 import { InjectRepository } from '@nestjs/typeorm';
 import { In, Repository } from 'typeorm';
@@ -130,7 +131,7 @@ export class LeaderboardService implements OnModuleInit {
 
     await Promise.all([
       this.cache.set(this.dataKey, leaders),
-      this.cache.set(this.cacheKey, leaders, { ttl: this.ttl }),
+      this.cache.set(this.cacheKey, leaders, this.ttl),
     ]);
   }
 
@@ -141,7 +142,7 @@ export class LeaderboardService implements OnModuleInit {
     }
 
     const top = await this.fetchTopPlayers();
-    await this.cache.set(this.cacheKey, top, { ttl: this.ttl });
+    await this.cache.set(this.cacheKey, top, this.ttl);
     return top;
   }
 

--- a/backend/src/services/translations.service.ts
+++ b/backend/src/services/translations.service.ts
@@ -39,7 +39,7 @@ export class TranslationsService {
       messages = await this.get('en');
     }
 
-    await this.cache.set(key, messages, { ttl: CACHE_TTL });
+    await this.cache.set(key, messages, CACHE_TTL);
     return messages;
   }
 }

--- a/backend/src/session/session.service.ts
+++ b/backend/src/session/session.service.ts
@@ -74,8 +74,7 @@ export class SessionService {
       await this.redis.set(
         `${this.refreshPrefix}${refreshToken}`,
         refreshValue,
-        'EX',
-        refreshTtl,
+        { EX: refreshTtl },
       );
       SessionService.tokensIssued.add(1);
       return { accessToken, refreshToken };

--- a/backend/src/wallet/wallet.service.ts
+++ b/backend/src/wallet/wallet.service.ts
@@ -378,7 +378,10 @@ export class WalletService {
 
   private async isDuplicateWebhook(eventId: string): Promise<boolean> {
     const key = `wallet:webhook:${eventId}`;
-    const res = await this.redis.set(key, '1', 'NX', 'EX', 60 * 60 * 24);
+    const res = await this.redis.set(key, '1', {
+      NX: true,
+      EX: 60 * 60 * 24,
+    });
     return res === null;
   }
 
@@ -725,7 +728,10 @@ export class WalletService {
             span.setStatus({ code: SpanStatusCode.OK });
             return JSON.parse(existing);
           }
-          const lock = await this.redis.set(redisKey, 'LOCK', 'NX', 'EX', 600);
+          const lock = await this.redis.set(redisKey, 'LOCK', {
+            NX: true,
+            EX: 600,
+          });
           if (lock === null) {
             const cached = await this.redis.get(redisKey);
             if (cached && cached !== 'LOCK') {
@@ -753,11 +759,10 @@ export class WalletService {
         await this.redis.set(
           this.challengeKey(challenge.id),
           JSON.stringify({ op: 'withdraw', accountId, amount, currency }),
-          'EX',
-          600,
+          { EX: 600 },
         );
         if (redisKey) {
-          await this.redis.set(redisKey, JSON.stringify(challenge), 'EX', 600);
+          await this.redis.set(redisKey, JSON.stringify(challenge), { EX: 600 });
         }
         span.setStatus({ code: SpanStatusCode.OK });
         return challenge;
@@ -794,7 +799,10 @@ export class WalletService {
             span.setStatus({ code: SpanStatusCode.OK });
             return JSON.parse(existing);
           }
-          const lock = await this.redis.set(redisKey, 'LOCK', 'NX', 'EX', 600);
+          const lock = await this.redis.set(redisKey, 'LOCK', {
+            NX: true,
+            EX: 600,
+          });
           if (lock === null) {
             const cached = await this.redis.get(redisKey);
             if (cached && cached !== 'LOCK') {
@@ -841,11 +849,10 @@ export class WalletService {
             currency,
             deviceId,
           }),
-          'EX',
-          600,
+          { EX: 600 },
         );
         if (redisKey) {
-          await this.redis.set(redisKey, JSON.stringify(challenge), 'EX', 600);
+          await this.redis.set(redisKey, JSON.stringify(challenge), { EX: 600 });
         }
         span.setStatus({ code: SpanStatusCode.OK });
         return challenge;
@@ -923,7 +930,10 @@ async initiateBankTransfer(
       if (existing && existing !== 'LOCK') {
         return JSON.parse(existing);
       }
-      const lock = await this.redis.set(redisKey, 'LOCK', 'NX', 'EX', 600);
+      const lock = await this.redis.set(redisKey, 'LOCK', {
+        NX: true,
+        EX: 600,
+      });
       if (lock === null) {
         const cached = await this.redis.get(redisKey);
         if (cached && cached !== 'LOCK') {
@@ -982,7 +992,7 @@ async initiateBankTransfer(
     };
 
     if (redisKey) {
-      await this.redis.set(redisKey, JSON.stringify(res), 'EX', 600);
+      await this.redis.set(redisKey, JSON.stringify(res), { EX: 600 });
     }
     return res;
   } catch (err) {
@@ -1095,7 +1105,10 @@ async rejectExpiredPendingDeposits(): Promise<void> {
 
   async confirmPendingDeposit(id: string, adminId: string): Promise<void> {
     const lockKey = `wallet:pending:${id}:lock`;
-    const lock = await this.redis.set(lockKey, '1', 'NX', 'EX', 30);
+    const lock = await this.redis.set(lockKey, '1', {
+      NX: true,
+      EX: 30,
+    });
     if (lock === null) throw new Error('Deposit locked');
     try {
       const deposit = await this.pendingDeposits.findOneBy({ id });
@@ -1149,7 +1162,10 @@ async rejectExpiredPendingDeposits(): Promise<void> {
     reason?: string,
   ): Promise<void> {
     const lockKey = `wallet:pending:${id}:lock`;
-    const lock = await this.redis.set(lockKey, '1', 'NX', 'EX', 30);
+    const lock = await this.redis.set(lockKey, '1', {
+      NX: true,
+      EX: 30,
+    });
     if (lock === null) throw new Error('Deposit locked');
     try {
       const deposit = await this.pendingDeposits.findOneBy({ id });

--- a/backend/src/wallet/webhook.controller.ts
+++ b/backend/src/wallet/webhook.controller.ts
@@ -39,7 +39,10 @@ export class WebhookController {
       throw new UnauthorizedException('invalid signature');
     }
     const key = `wallet:webhook:${eventId}`;
-    const stored = await this.redis.set(key, '1', 'NX', 'EX', 60 * 60 * 24);
+    const stored = await this.redis.set(key, '1', {
+      NX: true,
+      EX: 60 * 60 * 24,
+    });
     if (stored === null) {
       return { message: 'acknowledged' };
     }


### PR DESCRIPTION
## Summary
- switch Nest cache manager injections to use @nestjs/cache-manager with typed Cache dependencies and numeric TTLs
- harden Redis module configuration by validating redis.url before creating clients and returning typed CacheModuleOptions
- migrate Redis set usages to the object options form and guard optional BullMQ job retry calls across wallet, auth, and session flows

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d7bd17d0948323a8f37db44c6ae2ae

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Bug Fixes
  - Prevented rare retry-worker errors by guarding against undefined jobs.
  - Improved webhook reliability with safer idempotency handling.
  - Ensured consistent cache/expiry behavior across authentication, sessions, KYC, translations, leaderboard, and wallet flows.

* Refactor
  - Standardized Redis and cache TTL/option usage to a single, consistent API for improved maintainability.

* Chores
  - Added startup validation for Redis configuration with clearer error messages on misconfiguration.
  - Minor dependency/import cleanups to align with current cache module conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->