### PR TITLE
fix: align game gateway event payload typing

### DIFF
--- a/shared/events.ts
+++ b/shared/events.ts
@@ -14,6 +14,7 @@ const HandEndEvent = z.object({
   handId: z.string().uuid(),
   tableId: z.string().uuid().optional(),
   winners: z.array(z.string().uuid()).optional(),
+  stake: z.string().optional(),
 });
 
 const HandSettleEvent = z.object({
@@ -21,6 +22,7 @@ const HandSettleEvent = z.object({
   tableId: z.string().uuid().optional(),
   playerIds: z.array(z.string().uuid()),
   deltas: z.array(z.number()),
+  stake: z.string().optional(),
 });
 
 const WalletMovementEvent = z.object({


### PR DESCRIPTION
## Summary
- convert Socket.IO event typings to function signatures and update the enqueue helper to append schema versioning and track frame retries correctly
- reuse a shared base payload for player and spectator broadcasts while persisting snapshots as plain records
- extend shared event schemas with an optional stake field to match game engine emissions

## Testing
- npm run build *(fails: repository-wide TypeScript errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68d7bd18ddd88323abb36a45f4adbe9a