### PR TITLE
fix: align backend type imports with NodeNext

### DIFF
--- a/backend/parquetjs-lite.d.ts
+++ b/backend/parquetjs-lite.d.ts
@@ -1,1 +1,18 @@
-declare module 'parquetjs-lite';
+declare module 'parquetjs-lite' {
+  import type { Writable } from 'stream';
+
+  export class ParquetSchema {
+    constructor(schema: Record<string, unknown>);
+  }
+
+  export class ParquetWriter<TSchema = Record<string, unknown>> {
+    static openStream<T = Record<string, unknown>>(
+      schema: ParquetSchema,
+      stream: Writable,
+    ): Promise<ParquetWriter<T>>;
+
+    appendRow(row: TSchema): Promise<void>;
+
+    close(): Promise<void>;
+  }
+}

--- a/backend/src/analytics/analytics.service.ts
+++ b/backend/src/analytics/analytics.service.ts
@@ -21,8 +21,10 @@ import {
   detectSharedIP,
   detectSynchronizedBetting,
 } from '@shared/analytics/collusion';
-import { AlertItem, AlertItemSchema } from '@shared/schemas/analytics';
-import { AdminEvent, AdminEventSchema } from '../schemas/admin';
+import { AlertItemSchema } from '@shared/schemas/analytics';
+import type { AlertItem } from '@shared/schemas/analytics';
+import { AdminEventSchema } from '../schemas/admin';
+import type { AdminEvent } from '../schemas/admin';
 import type {
   Session as CollusionSession,
   Transfer as CollusionTransfer,

--- a/backend/src/analytics/etl.service.ts
+++ b/backend/src/analytics/etl.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, Logger, Inject, forwardRef } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import { Producer } from 'kafkajs';
+import type { Producer } from 'kafkajs';
 import { createKafkaProducer } from '../common/kafka';
 import Redis from 'ioredis';
 import Ajv, { ValidateFunction } from 'ajv';

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -11,26 +11,27 @@ import {
 } from '@nestjs/common';
 import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import {
-  LoginRequest,
   LoginRequestSchema,
-  type LoginResponse,
-  RegisterRequest,
   RegisterRequestSchema,
+  RefreshRequestSchema,
+  RequestResetSchema,
+  VerifyResetCodeSchema,
+  ResetPasswordSchema,
+} from '../schemas/auth';
+import type {
+  LoginRequest,
+  LoginResponse,
+  RegisterRequest,
   MessageResponse,
   RefreshRequest,
-  RefreshRequestSchema,
   RequestResetRequest,
-  RequestResetSchema,
   VerifyResetCodeRequest,
-  VerifyResetCodeSchema,
   ResetPasswordRequest,
-  ResetPasswordSchema,
   AuthProvidersResponse,
 } from '../schemas/auth';
 import { AuthService } from './auth.service';
 import { GeoIpService } from './geoip.service';
-import { Request } from 'express';
-import type { Response } from 'express';
+import type { Request, Response } from 'express';
 import { ConfigService } from '@nestjs/config';
 @ApiTags('auth')
 @Controller('auth')
@@ -63,7 +64,10 @@ export class AuthController {
     @Req() req: Request,
     @Res({ passthrough: true }) res: Response,
   ): Promise<LoginResponse> {
-    const ip = (req.headers['x-forwarded-for'] as string) || req.ip;
+    const forwardedFor = req.headers['x-forwarded-for'];
+    const ip = typeof forwardedFor === 'string' && forwardedFor.length > 0
+      ? forwardedFor
+      : req.ip ?? '';
     if (!this.geo.isAllowed(ip)) throw new ForbiddenException('Country not allowed');
     const parsed = LoginRequestSchema.parse(body);
     const tokens = await this.auth.login(parsed.email, parsed.password);
@@ -122,7 +126,10 @@ export class AuthController {
     @Req() req: Request,
   ): Promise<MessageResponse> {
     const parsed = RequestResetSchema.parse(body);
-    const ip = (req.headers['x-forwarded-for'] as string) || req.ip;
+    const forwardedFor = req.headers['x-forwarded-for'];
+    const ip = typeof forwardedFor === 'string' && forwardedFor.length > 0
+      ? forwardedFor
+      : req.ip ?? '';
     await this.auth.requestPasswordReset(parsed.email, ip);
     return { message: 'reset requested' };
   }

--- a/backend/src/auth/providers/gbg.provider.ts
+++ b/backend/src/auth/providers/gbg.provider.ts
@@ -1,4 +1,4 @@
-import { CountryProvider } from './country-provider';
+import type { CountryProvider } from './country-provider';
 import { HttpCountryProvider } from './http-country.provider';
 
 export function createGbgProvider(

--- a/backend/src/auth/providers/http-country.provider.ts
+++ b/backend/src/auth/providers/http-country.provider.ts
@@ -1,4 +1,4 @@
-import { CountryProvider } from './country-provider';
+import type { CountryProvider } from './country-provider';
 
 interface CountryResponse {
   countryCode?: string;

--- a/backend/src/auth/providers/index.ts
+++ b/backend/src/auth/providers/index.ts
@@ -1,8 +1,8 @@
 import { ConfigService } from '@nestjs/config';
-import { CountryProvider } from './country-provider';
+import type { CountryProvider } from './country-provider';
 import { createGbgProvider } from './gbg.provider';
 import { createTruliooProvider } from './trulioo.provider';
-export { CountryProvider } from './country-provider';
+export type { CountryProvider } from './country-provider';
 export { createGbgProvider } from './gbg.provider';
 export { createTruliooProvider } from './trulioo.provider';
 

--- a/backend/src/auth/providers/trulioo.provider.ts
+++ b/backend/src/auth/providers/trulioo.provider.ts
@@ -1,4 +1,4 @@
-import { CountryProvider } from './country-provider';
+import type { CountryProvider } from './country-provider';
 import { HttpCountryProvider } from './http-country.provider';
 
 export function createTruliooProvider(

--- a/backend/src/bootstrap.ts
+++ b/backend/src/bootstrap.ts
@@ -13,7 +13,7 @@ export async function bootstrap(options: BootstrapOptions = {}) {
   const { telemetry = true } = options;
   let telemetryExports: any;
   if (telemetry) {
-    telemetryExports = await import('./telemetry/telemetry');
+    telemetryExports = await import('./telemetry/telemetry.js');
     await telemetryExports.setupTelemetry();
   }
   const app = await NestFactory.create(AppModule, { bufferLogs: true });

--- a/backend/src/common/kyc.service.ts
+++ b/backend/src/common/kyc.service.ts
@@ -13,7 +13,7 @@ import type { Queue } from 'bullmq';
 import { Repository } from 'typeorm';
 import { KycVerification } from '../database/entities/kycVerification.entity';
 import { Account } from '../wallet/account.entity';
-import { CountryProvider } from '../auth/providers/country-provider';
+import type { CountryProvider } from '../auth/providers/country-provider';
 import { z } from 'zod';
 import { fetchJson } from '@shared/utils/http';
 import { Pep } from '../database/entities/pep.entity';

--- a/backend/src/events/events.service.ts
+++ b/backend/src/events/events.service.ts
@@ -1,7 +1,7 @@
 import { Inject, Injectable, Logger, OnModuleDestroy, Optional } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { metrics } from '@opentelemetry/api';
-import { Producer } from 'kafkajs';
+import type { Producer } from 'kafkajs';
 import { createKafkaProducer } from '../common/kafka';
 import { EventName, EventSchemas, Events } from '@shared/events';
 import type Redis from 'ioredis';
@@ -31,7 +31,7 @@ export class EventPublisher implements OnModuleDestroy {
 
   constructor(
     config: ConfigService,
-    producer = createKafkaProducer(config),
+    producer: Producer = createKafkaProducer(config),
     @Optional() @Inject('REDIS_CLIENT') private readonly redis?: Redis,
   ) {
     this.producer = producer;

--- a/backend/src/leaderboard/rebuild.ts
+++ b/backend/src/leaderboard/rebuild.ts
@@ -20,7 +20,7 @@ async function run(options: RebuildOptions = {}): Promise<{
   let app: INestApplicationContext | undefined;
   const service: LeaderboardService = options.service ??
     (await (async () => {
-      const { AppModule } = await import('../app.module');
+      const { AppModule } = await import('../app.module.js');
       app = await NestFactory.createApplicationContext(AppModule);
       return app.get(LeaderboardService);
     })());

--- a/backend/src/routes/admin-balance.controller.ts
+++ b/backend/src/routes/admin-balance.controller.ts
@@ -2,13 +2,12 @@ import { Post, Param, Body, Req, HttpCode } from '@nestjs/common';
 import { ApiOperation, ApiResponse } from '@nestjs/swagger';
 import type { Request } from 'express';
 import { AdminController } from './admin-base.controller';
-import {
-  AdminBalanceRequest,
-  AdminBalanceRequestSchema,
-} from '@shared/wallet.schema';
+import { AdminBalanceRequestSchema } from '@shared/wallet.schema';
+import type { AdminBalanceRequest } from '@shared/wallet.schema';
 import { WalletService } from '../wallet/wallet.service';
 import { AnalyticsService } from '../analytics/analytics.service';
-import { MessageResponse, MessageResponseSchema } from '../schemas/auth';
+import { MessageResponseSchema } from '../schemas/auth';
+import type { MessageResponse } from '../schemas/auth';
 
 @AdminController('balance')
 export class AdminBalanceController {

--- a/backend/src/routes/admin-bonus.controller.ts
+++ b/backend/src/routes/admin-bonus.controller.ts
@@ -3,14 +3,16 @@ import { ApiOperation, ApiResponse } from '@nestjs/swagger';
 import { AdminController } from './admin-base.controller';
 import { BonusService } from '../services/bonus.service';
 import {
-  BonusDefaultsResponse,
   BonusDefaultsResponseSchema,
-  BonusOptionsResponse,
   BonusOptionsResponseSchema,
-  BonusDefaultsRequest,
   BonusDefaultsRequestSchema,
-  BonusStatsResponse,
   BonusStatsResponseSchema,
+} from '../schemas/bonus';
+import type {
+  BonusDefaultsResponse,
+  BonusOptionsResponse,
+  BonusDefaultsRequest,
+  BonusStatsResponse,
 } from '../schemas/bonus';
 import { MessageResponseSchema } from '../schemas/auth';
 

--- a/backend/src/routes/admin-messages.controller.ts
+++ b/backend/src/routes/admin-messages.controller.ts
@@ -14,10 +14,11 @@ import { AdminGuard } from '../auth/admin.guard';
 import {
   AdminMessageSchema,
   AdminMessagesResponseSchema,
-  ReplyMessageRequest,
   ReplyMessageRequestSchema,
 } from '../schemas/messages';
-import { MessageResponse, MessageResponseSchema } from '../schemas/auth';
+import type { ReplyMessageRequest } from '../schemas/messages';
+import { MessageResponseSchema } from '../schemas/auth';
+import type { MessageResponse } from '../schemas/auth';
 import { AdminMessagesService } from '../notifications/admin-messages.service';
 
 @ApiTags('admin')

--- a/backend/src/routes/admin-tournaments.controller.ts
+++ b/backend/src/routes/admin-tournaments.controller.ts
@@ -13,10 +13,10 @@ import { AdminGuard } from '../auth/admin.guard';
 import {
   AdminTournamentSchema,
   TournamentSimulateRequestSchema,
-  TournamentSimulateResponse,
   TournamentFormatsResponseSchema,
   AdminTournamentFiltersResponseSchema,
 } from '../schemas/tournaments';
+import type { TournamentSimulateResponse } from '../schemas/tournaments';
 import { ZodError } from 'zod';
 import { simulate, type BlindLevel } from '@shared/utils/tournamentSimulator';
 import { BotProfilesResponseSchema } from '@shared/types';

--- a/backend/src/routes/admin.controller.ts
+++ b/backend/src/routes/admin.controller.ts
@@ -15,43 +15,47 @@ import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { z } from 'zod';
 import type { Request } from 'express';
 import {
-  KycDenialResponse,
   KycDenialResponseSchema,
   WalletReconcileMismatchesResponseSchema,
-  type WalletReconcileMismatchesResponse,
   WalletReconcileMismatchAcknowledgementSchema,
-  type WalletReconcileMismatchAcknowledgement,
+} from '@shared/wallet.schema';
+import type {
+  KycDenialResponse,
+  WalletReconcileMismatchesResponse,
+  WalletReconcileMismatchAcknowledgement,
 } from '@shared/wallet.schema';
 import {
-  AuditLogEntry,
   AuditLogEntrySchema,
+  AlertItemSchema,
+  RevenueBreakdownSchema,
+  RevenueTimeFilterSchema,
+} from '@shared/types';
+import type {
+  AuditLogEntry,
   AuditLogsResponse,
   AuditLogTypesResponse,
   AlertItem,
-  AlertItemSchema,
   RevenueBreakdown,
-  RevenueBreakdownSchema,
-  RevenueTimeFilterSchema,
   LogTypeClasses,
-  type RevenueTimeFilter,
+  RevenueTimeFilter,
 } from '@shared/types';
 import {
-  AdminTab,
   AdminTabResponseSchema,
-  AdminEvent,
   AdminEventsResponseSchema,
   AdminTabCreateRequestSchema,
-  type CreateAdminTabRequest,
   AdminTabUpdateRequestSchema,
-  type UpdateAdminTabRequest,
   AdminTabSchema,
   AdminTabMetaSchema,
-  type AdminTabMeta,
 } from '../schemas/admin';
-import {
-  MessageResponse,
-  MessageResponseSchema,
-} from '../schemas/auth';
+import type {
+  AdminTab,
+  AdminEvent,
+  CreateAdminTabRequest,
+  UpdateAdminTabRequest,
+  AdminTabMeta,
+} from '../schemas/admin';
+import { MessageResponseSchema } from '../schemas/auth';
+import type { MessageResponse } from '../schemas/auth';
 import { KycService } from '../wallet/kyc.service';
 import { AnalyticsService } from '../analytics/analytics.service';
 import { RevenueService } from '../wallet/revenue.service';


### PR DESCRIPTION
## Summary
- switch backend controllers and services to use `import type` for DTOs so Nest metadata emits under NodeNext
- treat dependency injection tokens such as CountryProvider and Kafka Producer as type-only and keep dynamic imports compatible with `.js` extensions
- declare ParquetSchema/ParquetWriter constructors in `parquetjs-lite.d.ts` for stronger typing

## Testing
- `npm run build --prefix backend` *(fails: existing type errors unrelated to TS1272/TS2709/TS2835 remain)*

------
https://chatgpt.com/codex/tasks/task_e_68d7bd1532c88323bcd59d27202c8665