### PR TITLE
feat(backend): align wallet DTOs with shared contract

### DIFF
--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -32,6 +32,7 @@ import { GeoIpService } from './geoip.service';
 import { Request } from 'express';
 import type { Response } from 'express';
 import { ConfigService } from '@nestjs/config';
+import { API_CONTRACT_VERSION } from '@shared/constants';
 @ApiTags('auth')
 @Controller('auth')
 export class AuthController {
@@ -80,7 +81,10 @@ export class AuthController {
   async register(@Body() body: RegisterRequest): Promise<MessageResponse> {
     const parsed = RegisterRequestSchema.parse(body);
     await this.auth.register(parsed.email, parsed.password);
-    return { message: 'registered' };
+    return {
+      message: 'registered',
+      contractVersion: API_CONTRACT_VERSION,
+    };
   }
 
   @Post('refresh')
@@ -110,7 +114,10 @@ export class AuthController {
     const parsed = RefreshRequestSchema.parse(body);
     await this.auth.logout(parsed.refreshToken);
     this.setRefreshCookie(res, '', 0);
-    return { message: 'logged out' };
+    return {
+      message: 'logged out',
+      contractVersion: API_CONTRACT_VERSION,
+    };
   }
 
   @Post('request-reset')
@@ -124,7 +131,10 @@ export class AuthController {
     const parsed = RequestResetSchema.parse(body);
     const ip = (req.headers['x-forwarded-for'] as string) || req.ip;
     await this.auth.requestPasswordReset(parsed.email, ip);
-    return { message: 'reset requested' };
+    return {
+      message: 'reset requested',
+      contractVersion: API_CONTRACT_VERSION,
+    };
   }
 
   @Post('verify-reset-code')
@@ -137,7 +147,10 @@ export class AuthController {
     const parsed = VerifyResetCodeSchema.parse(body);
     const ok = await this.auth.verifyResetCode(parsed.email, parsed.code);
     if (!ok) throw new UnauthorizedException('Invalid code');
-    return { message: 'code verified' };
+    return {
+      message: 'code verified',
+      contractVersion: API_CONTRACT_VERSION,
+    };
   }
 
   @Post('reset-password')
@@ -154,7 +167,10 @@ export class AuthController {
       parsed.password,
     );
     if (!ok) throw new UnauthorizedException('Invalid code');
-    return { message: 'password reset' };
+    return {
+      message: 'password reset',
+      contractVersion: API_CONTRACT_VERSION,
+    };
   }
 
   @Get('providers')

--- a/backend/src/promotions/promotions.service.ts
+++ b/backend/src/promotions/promotions.service.ts
@@ -2,6 +2,7 @@ import { ConflictException, Injectable, NotFoundException } from '@nestjs/common
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import type { MessageResponse, Promotion } from '@shared/types';
+import { API_CONTRACT_VERSION } from '@shared/constants';
 import { PromotionEntity } from '../database/entities/promotion.entity';
 import { PromotionClaimEntity } from '../database/entities/promotion-claim.entity';
 
@@ -40,6 +41,7 @@ export class PromotionsService {
 
     return {
       message: `Promotion "${promotion.title}" claimed`,
+      contractVersion: API_CONTRACT_VERSION,
     };
   }
 }

--- a/backend/src/routes/admin-balance.controller.ts
+++ b/backend/src/routes/admin-balance.controller.ts
@@ -9,6 +9,7 @@ import {
 import { WalletService } from '../wallet/wallet.service';
 import { AnalyticsService } from '../analytics/analytics.service';
 import { MessageResponse, MessageResponseSchema } from '../schemas/auth';
+import { API_CONTRACT_VERSION } from '@shared/constants';
 
 @AdminController('balance')
 export class AdminBalanceController {
@@ -35,6 +36,9 @@ export class AdminBalanceController {
       user: req.userId ?? 'admin',
       ip: req.ip || null,
     });
-    return MessageResponseSchema.parse({ message: 'ok' });
+    return MessageResponseSchema.parse({
+      message: 'ok',
+      contractVersion: API_CONTRACT_VERSION,
+    });
   }
 }

--- a/backend/src/routes/admin-bonus.controller.ts
+++ b/backend/src/routes/admin-bonus.controller.ts
@@ -13,6 +13,7 @@ import {
   BonusStatsResponseSchema,
 } from '../schemas/bonus';
 import { MessageResponseSchema } from '../schemas/auth';
+import { API_CONTRACT_VERSION } from '@shared/constants';
 
 @AdminController('bonus')
 export class AdminBonusController {
@@ -75,6 +76,9 @@ export class AdminBonusController {
   @ApiResponse({ status: 200, description: 'Defaults deleted' })
   async remove() {
     await this.bonusService.deleteDefaults();
-    return MessageResponseSchema.parse({ message: 'deleted' });
+    return MessageResponseSchema.parse({
+      message: 'deleted',
+      contractVersion: API_CONTRACT_VERSION,
+    });
   }
 }

--- a/backend/src/routes/admin-bonuses.controller.ts
+++ b/backend/src/routes/admin-bonuses.controller.ts
@@ -13,6 +13,7 @@ import {
   type BonusUpdateRequest,
 } from '../schemas/bonus';
 import { MessageResponseSchema } from '../schemas/auth';
+import { API_CONTRACT_VERSION } from '@shared/constants';
 
 @AdminController('bonuses')
 export class AdminBonusesController {
@@ -54,6 +55,9 @@ export class AdminBonusesController {
   @ApiResponse({ status: 200, description: 'Bonus deleted' })
   async remove(@Param('id') id: string) {
     await this.bonusService.remove(Number(id));
-    return MessageResponseSchema.parse({ message: 'deleted' });
+    return MessageResponseSchema.parse({
+      message: 'deleted',
+      contractVersion: API_CONTRACT_VERSION,
+    });
   }
 }

--- a/backend/src/routes/admin-messages.controller.ts
+++ b/backend/src/routes/admin-messages.controller.ts
@@ -18,6 +18,7 @@ import {
   ReplyMessageRequestSchema,
 } from '../schemas/messages';
 import { MessageResponse, MessageResponseSchema } from '../schemas/auth';
+import { API_CONTRACT_VERSION } from '@shared/constants';
 import { AdminMessagesService } from '../notifications/admin-messages.service';
 
 @ApiTags('admin')
@@ -48,7 +49,10 @@ export class AdminMessagesController {
       throw new NotFoundException('Message not found');
     }
     await this.service.markRead(Number(id));
-    return MessageResponseSchema.parse({ message: 'sent' });
+    return MessageResponseSchema.parse({
+      message: 'sent',
+      contractVersion: API_CONTRACT_VERSION,
+    });
   }
 
   @Post(':id/read')

--- a/backend/src/routes/admin-pending.controller.ts
+++ b/backend/src/routes/admin-pending.controller.ts
@@ -5,6 +5,8 @@ import type { ZodType } from 'zod';
 import { AuthGuard } from '../auth/auth.guard';
 import { AdminGuard } from '../auth/admin.guard';
 import { WalletService } from '../wallet/wallet.service';
+import { MessageResponseSchema } from '../schemas/auth';
+import { API_CONTRACT_VERSION } from '@shared/constants';
 
 interface AdminPendingControllerOpts<TListResponse, TRejectRequest> {
   path: string;
@@ -34,7 +36,7 @@ export default function AdminPendingTransactionsController<
   @ApiTags('admin')
   @UseGuards(AuthGuard, AdminGuard)
   class GenericPendingController {
-    constructor(private readonly wallet: WalletService) {}
+    constructor(readonly wallet: WalletService) {}
 
     @Get()
     @ApiOperation({ summary: 'List pending transactions' })
@@ -49,7 +51,10 @@ export default function AdminPendingTransactionsController<
     @ApiResponse({ status: 200, description: 'Transaction confirmed' })
     async confirm(@Param('id') id: string, @Req() req: Request) {
       await confirm(this.wallet, id, req);
-      return { message: 'confirmed' };
+      return MessageResponseSchema.parse({
+        message: 'confirmed',
+        contractVersion: API_CONTRACT_VERSION,
+      });
     }
 
     @Post(':id/reject')
@@ -62,7 +67,10 @@ export default function AdminPendingTransactionsController<
     ) {
       const parsed = request.parse(body);
       await reject(this.wallet, id, parsed, req);
-      return { message: 'rejected' };
+      return MessageResponseSchema.parse({
+        message: 'rejected',
+        contractVersion: API_CONTRACT_VERSION,
+      });
     }
   }
 

--- a/backend/src/routes/admin.controller.ts
+++ b/backend/src/routes/admin.controller.ts
@@ -52,6 +52,7 @@ import {
   MessageResponse,
   MessageResponseSchema,
 } from '../schemas/auth';
+import { API_CONTRACT_VERSION } from '@shared/constants';
 import { KycService } from '../wallet/kyc.service';
 import { AnalyticsService } from '../analytics/analytics.service';
 import { RevenueService } from '../wallet/revenue.service';
@@ -153,7 +154,10 @@ export class AdminController {
     @Param('id') id: string,
   ): Promise<MessageResponse> {
     await this.analytics.acknowledgeAdminEvent(id);
-    return MessageResponseSchema.parse({ message: 'acknowledged' });
+    return MessageResponseSchema.parse({
+      message: 'acknowledged',
+      contractVersion: API_CONTRACT_VERSION,
+    });
   }
 
   @Get('tabs')

--- a/backend/src/routes/bank-reconciliation.controller.ts
+++ b/backend/src/routes/bank-reconciliation.controller.ts
@@ -22,6 +22,8 @@ import {
   BankReconciliationRequestSchema,
   type BankReconciliationRequest,
 } from '@shared/wallet.schema';
+import { MessageResponseSchema } from '../schemas/auth';
+import { API_CONTRACT_VERSION } from '@shared/constants';
 
 @ApiTags('admin')
 @UseGuards(AuthGuard, AdminGuard)
@@ -77,6 +79,9 @@ export class BankReconciliationController {
       const parsed = BankReconciliationRequestSchema.parse(body);
       await this.reconciliation.reconcileApi(parsed.entries);
     }
-    return { message: 'reconciled' };
+    return MessageResponseSchema.parse({
+      message: 'reconciled',
+      contractVersion: API_CONTRACT_VERSION,
+    });
   }
 }

--- a/backend/src/routes/rate-limit.guard.ts
+++ b/backend/src/routes/rate-limit.guard.ts
@@ -16,6 +16,7 @@ import {
   ThrottlerStorage,
 } from '@nestjs/throttler';
 import type { MessageResponse } from '@shared/types';
+import { API_CONTRACT_VERSION } from '@shared/constants';
 
 @Injectable()
 export class RateLimitGuard extends ThrottlerGuard {
@@ -40,7 +41,10 @@ export class RateLimitGuard extends ThrottlerGuard {
     _context: ExecutionContext,
     _detail: ThrottlerLimitDetail,
   ): Promise<void> {
-    const body: MessageResponse = { message: 'Too Many Requests' };
+    const body: MessageResponse = {
+      message: 'Too Many Requests',
+      contractVersion: API_CONTRACT_VERSION,
+    };
     throw new HttpException(body, HttpStatus.TOO_MANY_REQUESTS);
   }
 }

--- a/backend/src/routes/wallet.controller.ts
+++ b/backend/src/routes/wallet.controller.ts
@@ -34,6 +34,8 @@ import {
   type TxRequest,
 } from '@shared/wallet.schema';
 import { ZodError } from '@shared/types';
+import { MessageResponseSchema } from '../schemas/auth';
+import { API_CONTRACT_VERSION } from '@shared/constants';
 
 @UseGuards(AuthGuard, RateLimitGuard, SelfGuard)
 @ApiTags('wallet')
@@ -55,7 +57,10 @@ export class WalletController {
     try {
       const parsed = TxSchema.parse(body);
       await this.wallet.reserve(id, parsed.amount, parsed.tx, parsed.currency);
-      return { message: 'reserved' };
+      return MessageResponseSchema.parse({
+        message: 'reserved',
+        contractVersion: API_CONTRACT_VERSION,
+      });
     } catch (err) {
       if (err instanceof ZodError) {
         throw new BadRequestException(err.errors);
@@ -74,8 +79,16 @@ export class WalletController {
   ) {
     try {
       const parsed = TxSchema.parse(body);
-      await this.wallet.commit(parsed.tx, parsed.amount, parsed.rake ?? 0, parsed.currency);
-      return { message: 'committed' };
+      await this.wallet.commit(
+        parsed.tx,
+        parsed.amount,
+        parsed.rake ?? 0,
+        parsed.currency,
+      );
+      return MessageResponseSchema.parse({
+        message: 'committed',
+        contractVersion: API_CONTRACT_VERSION,
+      });
     } catch (err) {
       if (err instanceof ZodError) {
         throw new BadRequestException(err.errors);
@@ -95,7 +108,10 @@ export class WalletController {
     try {
       const parsed = TxSchema.parse(body);
       await this.wallet.rollback(id, parsed.amount, parsed.tx, parsed.currency);
-      return { message: 'rolled back' };
+      return MessageResponseSchema.parse({
+        message: 'rolled back',
+        contractVersion: API_CONTRACT_VERSION,
+      });
     } catch (err) {
       if (err instanceof ZodError) {
         throw new BadRequestException(err.errors);
@@ -126,7 +142,10 @@ export class WalletController {
         parsed.currency,
         idempotencyKey,
       );
-      return { message: 'withdrawn' };
+      return MessageResponseSchema.parse({
+        message: 'withdrawn',
+        contractVersion: API_CONTRACT_VERSION,
+      });
     } catch (err) {
       if (err instanceof ZodError) {
         throw new BadRequestException(err.errors);
@@ -205,7 +224,10 @@ export class WalletController {
     @Req() _req: Request,
   ) {
     await this.wallet.cancelPendingDeposit(id, depositId);
-    return { message: 'cancelled' };
+    return MessageResponseSchema.parse({
+      message: 'cancelled',
+      contractVersion: API_CONTRACT_VERSION,
+    });
   }
 
   @Post(':id/kyc')
@@ -213,7 +235,10 @@ export class WalletController {
   @ApiResponse({ status: 200, description: 'KYC verification started' })
   async verify(@Param('id') id: string, @Req() _req: Request) {
     await this.kyc.verify(id);
-    return { message: 'verified' };
+    return MessageResponseSchema.parse({
+      message: 'verified',
+      contractVersion: API_CONTRACT_VERSION,
+    });
   }
 
   @Get(':id/status')

--- a/backend/src/schemas/auth.ts
+++ b/backend/src/schemas/auth.ts
@@ -16,6 +16,7 @@ export type LoginResponse = z.infer<typeof LoginResponseSchema>;
 
 export const MessageResponseSchema = z.object({
   message: z.string(),
+  contractVersion: z.string(),
 });
 export type MessageResponse = z.infer<typeof MessageResponseSchema>;
 

--- a/backend/src/test-support/test-support.controller.ts
+++ b/backend/src/test-support/test-support.controller.ts
@@ -1,6 +1,8 @@
 import { Body, Controller, Delete, Param, Post } from '@nestjs/common';
 import { z } from 'zod';
 import { TestSupportService } from './test-support.service';
+import { MessageResponseSchema } from '../schemas/auth';
+import { API_CONTRACT_VERSION } from '@shared/constants';
 
 const SeedUserSchema = z.object({
   email: z.string().email(),
@@ -45,6 +47,9 @@ export class TestSupportController {
   @Delete('collusion/:sessionId')
   async deleteCollusion(@Param('sessionId') sessionId: string) {
     await this.support.deleteCollusion(sessionId);
-    return { message: 'deleted' };
+    return MessageResponseSchema.parse({
+      message: 'deleted',
+      contractVersion: API_CONTRACT_VERSION,
+    });
   }
 }

--- a/backend/src/tournament/tournament.controller.ts
+++ b/backend/src/tournament/tournament.controller.ts
@@ -22,6 +22,8 @@ import type {
 import type { Request } from 'express';
 import { TournamentFiltersResponseSchema } from '@shared/types';
 import { BotProfilesResponseSchema } from '@shared/types';
+import { MessageResponseSchema } from '../schemas/auth';
+import { API_CONTRACT_VERSION } from '@shared/constants';
 
 @UseGuards(RateLimitGuard)
 @ApiTags('tournaments')
@@ -74,7 +76,10 @@ export class TournamentController {
   @ApiResponse({ status: 200, description: 'Withdrawn from tournament' })
   async withdraw(@Param('id') id: string, @Req() req: Request) {
     await this.service.withdraw(id, req.userId);
-    return { message: 'tournament withdrawal' };
+    return MessageResponseSchema.parse({
+      message: 'tournament withdrawal',
+      contractVersion: API_CONTRACT_VERSION,
+    });
   }
 
   @Post(':id/cancel')
@@ -84,7 +89,10 @@ export class TournamentController {
   @ApiResponse({ status: 200, description: 'Tournament cancelled' })
   async cancel(@Param('id') id: string) {
     await this.service.cancel(id);
-    return { message: 'tournament cancelled' };
+    return MessageResponseSchema.parse({
+      message: 'tournament cancelled',
+      contractVersion: API_CONTRACT_VERSION,
+    });
   }
 
   @Post(':id/prizes')
@@ -138,6 +146,9 @@ export class TournamentController {
       })),
       start: new Date(body.startTime),
     });
-    return { message: 'tournament scheduled' };
+    return MessageResponseSchema.parse({
+      message: 'tournament scheduled',
+      contractVersion: API_CONTRACT_VERSION,
+    });
   }
 }

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -4,7 +4,6 @@ import { withSpan } from '../common/tracing';
 import {
   CreateUserRequest,
   UpdateUserRequest,
-  User,
   type UserProfile,
   type ProfileStatsResponse,
 } from '@shared/types';
@@ -13,6 +12,7 @@ import { QueryFailedError, In } from 'typeorm';
 import { Account } from '../wallet/account.entity';
 import { Leaderboard } from '../database/entities/leaderboard.entity';
 import * as bcrypt from 'bcrypt';
+import type { User as UserEntity } from '../database/entities/user.entity';
 
 @Injectable()
 export class UsersService {
@@ -22,7 +22,7 @@ export class UsersService {
   private async withUser<T>(
     id: string,
     span: Span,
-    fn: (user: User) => Promise<T>,
+    fn: (user: UserEntity) => Promise<T>,
   ): Promise<T> {
     span.setAttribute('user.id', id);
     const user = await this.users.findOne({ where: { id } });
@@ -32,7 +32,7 @@ export class UsersService {
     return fn(user);
   }
 
-  async create(data: CreateUserRequest): Promise<User> {
+  async create(data: CreateUserRequest): Promise<UserEntity> {
     return withSpan('users.create', async (span) => {
       try {
         const passwordHash = data.password
@@ -61,7 +61,7 @@ export class UsersService {
     });
   }
 
-  async findById(id: string): Promise<User> {
+  async findById(id: string): Promise<UserEntity> {
     return withSpan('users.findById', async (span) => {
       span.setAttribute('user.id', id);
       const user = await this.users.findOne({ where: { id } });
@@ -122,7 +122,7 @@ export class UsersService {
     });
   }
 
-  async update(id: string, data: UpdateUserRequest): Promise<User> {
+  async update(id: string, data: UpdateUserRequest): Promise<UserEntity> {
     return withSpan('users.update', (span) => {
       return this.withUser(id, span, async (user) => {
         Object.assign(user, data);
@@ -131,7 +131,7 @@ export class UsersService {
     });
   }
 
-  async ban(id: string): Promise<User> {
+  async ban(id: string): Promise<UserEntity> {
     return withSpan('users.ban', (span) => {
       return this.withUser(id, span, async (user) => {
         user.banned = true;
@@ -140,7 +140,7 @@ export class UsersService {
     });
   }
 
-  async list(limit?: number): Promise<(User & { currency: string })[]> {
+  async list(limit?: number): Promise<(UserEntity & { currency: string })[]> {
     return withSpan('users.list', async (span) => {
       const users = await this.users.find({
         order: { joined: 'DESC' },

--- a/backend/src/wallet/wallet.service.ts
+++ b/backend/src/wallet/wallet.service.ts
@@ -37,6 +37,7 @@ import type {
   WalletReconcileMismatchAcknowledgement,
 } from '@shared/wallet.schema';
 import type { PendingWithdrawal } from '@shared/types';
+import type { PendingDeposit as PendingDepositDto } from '@shared/wallet.schema';
 import type { Events } from '@shared/events';
 
 interface Movement {
@@ -1081,15 +1082,29 @@ async rejectExpiredPendingDeposits(): Promise<void> {
 }
 
 
-  async listPendingDeposits() {
+  async listPendingDeposits(): Promise<PendingDepositDto[]> {
     const deposits = await this.pendingDeposits.find({
       where: { status: 'pending', actionRequired: true },
       order: { createdAt: 'ASC' },
     });
-    return deposits.map((d) => ({
-      ...d,
+    return deposits.map<PendingDepositDto>((deposit) => ({
+      id: deposit.id,
+      userId: deposit.userId,
+      amount: deposit.amount,
+      currency: deposit.currency,
+      reference: deposit.reference,
+      status: deposit.status,
+      actionRequired: deposit.actionRequired,
+      expiresAt: deposit.expiresAt.toISOString(),
       avatar: '',
-      method: 'Bank Transfer',
+      method: 'bank-transfer',
+      confirmedBy: deposit.confirmedBy ?? undefined,
+      confirmedAt: deposit.confirmedAt?.toISOString(),
+      rejectedBy: deposit.rejectedBy ?? undefined,
+      rejectedAt: deposit.rejectedAt?.toISOString(),
+      rejectionReason: deposit.rejectionReason ?? undefined,
+      createdAt: deposit.createdAt.toISOString(),
+      updatedAt: deposit.updatedAt.toISOString(),
     }));
   }
 

--- a/backend/src/wallet/webhook.controller.ts
+++ b/backend/src/wallet/webhook.controller.ts
@@ -12,6 +12,8 @@ import type { Request } from 'express';
 import type { Redis } from 'ioredis';
 import { WalletService } from './wallet.service';
 import { PaymentProviderService } from './payment-provider.service';
+import { MessageResponseSchema } from '../schemas/auth';
+import { API_CONTRACT_VERSION } from '@shared/constants';
 
 @ApiTags('wallet')
 @Controller('wallet/provider')
@@ -41,9 +43,15 @@ export class WebhookController {
     const key = `wallet:webhook:${eventId}`;
     const stored = await this.redis.set(key, '1', 'NX', 'EX', 60 * 60 * 24);
     if (stored === null) {
-      return { message: 'acknowledged' };
+      return MessageResponseSchema.parse({
+        message: 'acknowledged',
+        contractVersion: API_CONTRACT_VERSION,
+      });
     }
     await this.provider.confirm3DS(body);
-    return { message: 'acknowledged' };
+    return MessageResponseSchema.parse({
+      message: 'acknowledged',
+      contractVersion: API_CONTRACT_VERSION,
+    });
   }
 }

--- a/backend/src/withdrawals/withdrawals.controller.ts
+++ b/backend/src/withdrawals/withdrawals.controller.ts
@@ -11,6 +11,8 @@ import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { WithdrawalsService } from './withdrawals.service';
 import { WithdrawalDecisionRequestSchema } from '../schemas/withdrawals';
 import { AdminGuard } from '../auth/admin.guard';
+import { MessageResponseSchema } from '../schemas/auth';
+import { API_CONTRACT_VERSION } from '@shared/constants';
 
 @UseGuards(AdminGuard)
 @ApiTags('withdrawals')
@@ -29,7 +31,10 @@ export class WithdrawalsController {
   ) {
     const { comment } = WithdrawalDecisionRequestSchema.parse(body);
     await this.withdrawals.approve(user, req.userId, comment);
-    return { message: 'approved' };
+    return MessageResponseSchema.parse({
+      message: 'approved',
+      contractVersion: API_CONTRACT_VERSION,
+    });
   }
 
   @Post(':user/reject')
@@ -43,7 +48,10 @@ export class WithdrawalsController {
   ) {
     const { comment } = WithdrawalDecisionRequestSchema.parse(body);
     await this.withdrawals.reject(user, req.userId, comment);
-    return { message: 'rejected' };
+    return MessageResponseSchema.parse({
+      message: 'rejected',
+      contractVersion: API_CONTRACT_VERSION,
+    });
   }
 }
 


### PR DESCRIPTION
## Summary
- serialize pending deposit DTOs using ISO timestamps and expose wallet service types consistent with the shared schema
- attach the shared API contract version to status/message responses across wallet, admin, auth, and notification endpoints
- return entity-typed users from the service so downstream consumers can rely on email, bank, and balance fields

## Testing
- npm run build --prefix backend *(fails: existing TypeScript errors in analytics, telemetry, and controller factories)*

------
https://chatgpt.com/codex/tasks/task_e_68d7bd199f648323838b26f7dc93c1b2