### PR TITLE
Fix telemetry instrumentation types for OpenTelemetry update

### DIFF
--- a/backend/src/telemetry/telemetry.ts
+++ b/backend/src/telemetry/telemetry.ts
@@ -8,7 +8,7 @@ import { ExpressInstrumentation } from '@opentelemetry/instrumentation-express';
 import { IORedisInstrumentation } from '@opentelemetry/instrumentation-ioredis';
 import { PgInstrumentation } from '@opentelemetry/instrumentation-pg';
 import { AmqplibInstrumentation } from '@opentelemetry/instrumentation-amqplib';
-import { KafkajsInstrumentation } from '@opentelemetry/instrumentation-kafkajs';
+import { KafkaJsInstrumentation } from '@opentelemetry/instrumentation-kafkajs';
 import { SocketIoInstrumentation } from '@opentelemetry/instrumentation-socket.io';
 import { PinoInstrumentation } from '@opentelemetry/instrumentation-pino';
 import { NestInstrumentation } from '@opentelemetry/instrumentation-nestjs-core';
@@ -26,7 +26,7 @@ export function setupTelemetry(): Promise<void> {
       new IORedisInstrumentation(),
       new PgInstrumentation(),
       new AmqplibInstrumentation(),
-      new KafkajsInstrumentation(),
+      new KafkaJsInstrumentation(),
       new SocketIoInstrumentation(),
       new PinoInstrumentation(),
       new NestInstrumentation(),

--- a/shared/telemetry/index.ts
+++ b/shared/telemetry/index.ts
@@ -5,6 +5,7 @@ import { metrics, type Counter, type Histogram, type ObservableResult } from '@o
 import {
   MeterProvider,
   PeriodicExportingMetricReader,
+  type PushMetricExporter,
 } from '@opentelemetry/sdk-metrics';
 import { OTLPMetricExporter } from '@opentelemetry/exporter-metrics-otlp-http';
 import { logs } from '@opentelemetry/api-logs';
@@ -17,14 +18,14 @@ import {
 import { OTLPLogExporter } from '@opentelemetry/exporter-logs-otlp-http';
 import { Resource } from '@opentelemetry/resources';
 import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
-import type { Instrumentation } from '@opentelemetry/instrumentation';
+import type { InstrumentationBase } from '@opentelemetry/instrumentation';
 import type { Request, Response, NextFunction } from 'express';
 import { addSample, recordTimestamp, percentile } from './metrics';
 
 interface TelemetryOptions {
   serviceName: string;
   meterName: string;
-  instrumentations: Instrumentation[];
+  instrumentations: InstrumentationBase[];
   enableHttpMetrics?: boolean;
 }
 
@@ -104,7 +105,9 @@ export async function setupTelemetry({
   if (otlpMetricsEndpoint) {
     const otlpExporter = new OTLPMetricExporter({ url: otlpMetricsEndpoint });
     meterProvider.addMetricReader(
-      new PeriodicExportingMetricReader({ exporter: otlpExporter }),
+      new PeriodicExportingMetricReader({
+        exporter: otlpExporter as unknown as PushMetricExporter,
+      }),
     );
   }
   metrics.setGlobalMeterProvider(meterProvider);


### PR DESCRIPTION
## Summary
- replace the backend KafkaJS instrumentation import/constructor with the updated KafkaJsInstrumentation class
- update the shared telemetry helper to type instrumentations via InstrumentationBase and cast the OTLP metric exporter for the periodic metric reader

## Testing
- npm run build *(fails: existing type errors in frontend/test-utils and shared events/types)*

------
https://chatgpt.com/codex/tasks/task_e_68d7c3a010c8832390ddbf1499ead1d3