### PR TITLE
fix: tighten backend typing for shared helpers

### DIFF
--- a/backend/src/common/controllers/list.controller.ts
+++ b/backend/src/common/controllers/list.controller.ts
@@ -27,7 +27,7 @@ export function createListController<
     @ApiResponse({ status: 200, description: metadata.description })
     async list(): Promise<R> {
       const data = (await this.service.list()) as T;
-      return transform ? transform(data) : data;
+      return transform ? transform(data) : ((data as unknown) as R);
     }
   }
 

--- a/backend/src/history/history.repository.ts
+++ b/backend/src/history/history.repository.ts
@@ -1,4 +1,9 @@
-import { DataSource, EntityTarget, Repository } from 'typeorm';
+import {
+  DataSource,
+  EntityTarget,
+  Repository,
+  type ObjectLiteral,
+} from 'typeorm';
 
 /**
  * Generic repository for history entities.
@@ -6,7 +11,7 @@ import { DataSource, EntityTarget, Repository } from 'typeorm';
  * Each history entity (game, tournament, wallet) can reuse this class
  * instead of having its own repository implementation.
  */
-export class HistoryRepository<T> extends Repository<T> {
+export class HistoryRepository<T extends ObjectLiteral> extends Repository<T> {
   constructor(entity: EntityTarget<T>, dataSource: DataSource) {
     super(entity, dataSource.createEntityManager());
   }

--- a/backend/src/leaderboard/leaderboard.service.ts
+++ b/backend/src/leaderboard/leaderboard.service.ts
@@ -2,7 +2,7 @@ import { Inject, Injectable, OnModuleInit } from '@nestjs/common';
 import { CACHE_MANAGER } from '@nestjs/cache-manager';
 import { Cache } from 'cache-manager';
 import { InjectRepository } from '@nestjs/typeorm';
-import { In, Repository } from 'typeorm';
+import { In, Repository, type DeepPartial } from 'typeorm';
 import { readFileSync } from 'fs';
 import { join } from 'path';
 import { metrics } from '@opentelemetry/api';
@@ -125,7 +125,11 @@ export class LeaderboardService implements OnModuleInit {
 
     await this._leaderboardRepo.clear();
     if (rows.length) {
-      await this._leaderboardRepo.insert(rows);
+      const payload = rows.map<DeepPartial<Leaderboard>>((row) => ({
+        ...row,
+        finishes: row.finishes ?? {},
+      }));
+      await this._leaderboardRepo.insert(payload);
     }
 
     const leaders = rows.slice(0, 100).map(toLeaderboardEntry);

--- a/backend/src/leaderboard/score-utils.ts
+++ b/backend/src/leaderboard/score-utils.ts
@@ -89,7 +89,7 @@ export interface LeaderboardRow {
   hands: number;
   duration: number;
   buyIn: number;
-  finishes?: Record<number, number> | null;
+  finishes: Record<number, number>;
 }
 
 export function toLeaderboardRow(
@@ -108,7 +108,7 @@ export function toLeaderboardRow(
     hands: entry.hands,
     duration: entry.duration,
     buyIn: entry.buyIn,
-    finishes: entry.finishes,
+    finishes: entry.finishes ?? {},
   };
 }
 
@@ -123,7 +123,7 @@ export function toLeaderboardEntry(row: LeaderboardRow): LeaderboardEntry {
     bb100: row.hands ? (row.bb / row.hands) * 100 : 0,
     hours: row.duration / 3600000,
     roi: row.buyIn ? row.net / row.buyIn : 0,
-    finishes: row.finishes ?? {},
+    finishes: row.finishes,
   };
 }
 

--- a/backend/src/routes/game-types.controller.ts
+++ b/backend/src/routes/game-types.controller.ts
@@ -2,7 +2,9 @@ import { type GameTypeList } from '../schemas/game-types';
 import { GameTypesService } from '../game-types/game-types.service';
 import { createListController } from '../common/controllers/list.controller';
 
-export const GameTypesController = createListController<
+export const GameTypesController: ReturnType<
+  typeof createListController<GameTypesService, GameTypeList>
+> = createListController<
   GameTypesService,
   GameTypeList
 >(

--- a/backend/src/services/simple-list.service.ts
+++ b/backend/src/services/simple-list.service.ts
@@ -1,6 +1,6 @@
-import { Repository, FindOptionsOrder } from 'typeorm';
+import { Repository, FindOptionsOrder, type ObjectLiteral } from 'typeorm';
 
-export class SimpleListService<T> {
+export class SimpleListService<T extends ObjectLiteral> {
   constructor(protected readonly repo: Repository<T>) {}
 
   protected find(order: FindOptionsOrder<T> = {}): Promise<T[]> {

--- a/backend/src/tournament/tournament.service.ts
+++ b/backend/src/tournament/tournament.service.ts
@@ -22,6 +22,7 @@ import { FeatureFlagsService } from '../feature-flags/feature-flags.service';
 import { EventPublisher } from '../events/events.service';
 import { WalletService } from '../wallet/wallet.service';
 import {
+  AdminTournamentFiltersResponseSchema,
   TournamentFiltersResponseSchema,
   type TournamentFilterOption,
   type AdminTournament,
@@ -147,11 +148,17 @@ export class TournamentService implements OnModuleInit {
     });
 
     if (dbFilters && dbFilters.length > 0) {
-      return dbFilters.map(({ id, label, colorClass }) => ({
-        id,
-        label,
-        ...(colorClass ? { colorClass } : {}),
-      }));
+      const parsed = AdminTournamentFiltersResponseSchema.safeParse(
+        dbFilters.map(({ id, label, colorClass }) => ({
+          id,
+          label,
+          ...(colorClass ? { colorClass } : {}),
+        })),
+      );
+
+      if (parsed.success) {
+        return parsed.data;
+      }
     }
 
     return DEFAULT_ADMIN_TOURNAMENT_FILTERS.map((filter) => ({ ...filter }));

--- a/backend/src/wallet/transactions.service.ts
+++ b/backend/src/wallet/transactions.service.ts
@@ -21,7 +21,10 @@ import {
   type FilterOptions,
   type TransactionColumn,
 } from '@shared/transactions.schema';
-import type { TransactionTab } from '@shared/wallet.schema';
+import {
+  TransactionTabsResponseSchema,
+  type TransactionTab,
+} from '@shared/wallet.schema';
 import { TransactionColumnEntity } from './transaction-column.entity';
 
 @Injectable()
@@ -71,7 +74,9 @@ export class TransactionsService {
 
   async getTransactionTabs(): Promise<TransactionTab[]> {
     const tabs = await this.tabRepo.find();
-    return tabs.map((t) => ({ id: t.id, label: t.label }));
+    return TransactionTabsResponseSchema.parse(
+      tabs.map((t) => ({ id: t.id, label: t.label })),
+    );
   }
 
   async getTransactionColumns() {


### PR DESCRIPTION
## Summary
- add ObjectLiteral constraints to shared repositories/services and tighten list controller typing
- ensure leaderboard rows always carry finish counts and persist via DeepPartial inserts
- validate wallet transaction tabs and admin tournament filter IDs against shared schemas

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d7c3a419708323bb22b87dd91cb56c