### PR TITLE
fix(backend): align bonus claims handling with shared schemas

### DIFF
--- a/backend/src/schemas/bonus.ts
+++ b/backend/src/schemas/bonus.ts
@@ -26,14 +26,23 @@ export const BonusDefaultsRequestSchema = BonusDefaultsResponseSchema;
 
 export type BonusDefaultsRequest = z.infer<typeof BonusDefaultsRequestSchema>;
 
+const NullableClaimSchema = z
+  .number()
+  .int()
+  .nonnegative()
+  .nullable()
+  .optional();
+
 const BonusBaseSchema = BonusDefaultsResponseSchema.extend({
   description: z.string(),
+  claimsTotal: NullableClaimSchema,
+  claimsWeek: NullableClaimSchema,
 });
 
 export const BonusSchema = BonusBaseSchema.extend({
   id: z.number().int(),
-  claimsTotal: z.number().int(),
-  claimsWeek: z.number().int(),
+  claimsTotal: z.number().int().nonnegative(),
+  claimsWeek: z.number().int().nonnegative(),
 });
 
 export type Bonus = z.infer<typeof BonusSchema>;

--- a/backend/src/schemas/tournaments.ts
+++ b/backend/src/schemas/tournaments.ts
@@ -128,6 +128,13 @@ export type CalculatePrizesResponse = z.infer<
   typeof CalculatePrizesResponseSchema
 >;
 
+export const HotPatchLevelRequestSchema = z.object({
+  level: z.number().int().nonnegative(),
+  smallBlind: z.number().int().nonnegative(),
+  bigBlind: z.number().int().nonnegative(),
+});
+export type HotPatchLevelRequest = z.infer<typeof HotPatchLevelRequestSchema>;
+
 export const TournamentStateSchema = z.enum([
   'REG_OPEN',
   'RUNNING',

--- a/backend/src/services/bonus.helpers.ts
+++ b/backend/src/services/bonus.helpers.ts
@@ -32,11 +32,16 @@ type BonusBaseFields = Pick<
   | 'status'
 >;
 
-function nullableNumber(value: number | null | undefined): number | null {
+function nullableNumber(value: unknown): number | null | undefined {
   if (typeof value === 'number') {
     return Number.isFinite(value) ? value : null;
   }
-  return null;
+
+  if (value === null) {
+    return null;
+  }
+
+  return undefined;
 }
 
 function mapBonusBaseFields(source: BonusBaseSource): BonusBaseFields {
@@ -81,10 +86,20 @@ export function toBonusEntityInput(
   if ('eligibility' in payload) prepared.eligibility = payload.eligibility;
   if ('status' in payload) prepared.status = payload.status;
   if ('claimsTotal' in payload) {
-    prepared.claimsTotal = nullableNumber(payload.claimsTotal);
+    const claimsTotal = nullableNumber(
+      (payload as { claimsTotal?: unknown }).claimsTotal,
+    );
+    if (claimsTotal !== undefined) {
+      prepared.claimsTotal = claimsTotal;
+    }
   }
   if ('claimsWeek' in payload) {
-    prepared.claimsWeek = nullableNumber(payload.claimsWeek);
+    const claimsWeek = nullableNumber(
+      (payload as { claimsWeek?: unknown }).claimsWeek,
+    );
+    if (claimsWeek !== undefined) {
+      prepared.claimsWeek = claimsWeek;
+    }
   }
 
   return prepared;

--- a/backend/src/services/bonus.service.ts
+++ b/backend/src/services/bonus.service.ts
@@ -184,10 +184,11 @@ export class BonusService {
 
   async create(payload: BonusCreateRequest): Promise<Bonus> {
     const parsed = BonusCreateRequestSchema.parse(payload);
+    const normalized = toBonusEntityInput(parsed);
     const entity = this.bonuses.create({
-      ...toBonusEntityInput(parsed),
-      claimsTotal: parsed.claimsTotal ?? 0,
-      claimsWeek: parsed.claimsWeek ?? 0,
+      ...normalized,
+      claimsTotal: normalized.claimsTotal ?? 0,
+      claimsWeek: normalized.claimsWeek ?? 0,
     });
     const saved = await this.bonuses.save(entity);
     return BonusSchema.parse(mapBonusEntity(saved));

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -3,6 +3,7 @@ import { MessageResponseSchema as AuthMessageResponseSchema } from '../backend/s
 import type { MessageResponse as AuthMessageResponse } from '../backend/src/schemas/auth';
 import { SidePotSchema } from './schemas/sidePot';
 import { GameTypeSchema } from '../backend/src/schemas/game-types';
+import type { BonusCreateRequest } from '../backend/src/schemas/bonus';
 import {
   GameHistoryEntrySchema,
   TournamentHistoryEntrySchema,
@@ -350,9 +351,10 @@ export type {
   Bonus,
   BonusesResponse,
   BonusStatsResponse,
-  BonusCreateRequest,
   BonusUpdateRequest,
 } from '../backend/src/schemas/bonus';
+
+export type { BonusCreateRequest } from '../backend/src/schemas/bonus';
 
 export type BonusUpdatePayload = BonusCreateRequest;
 
@@ -416,6 +418,7 @@ export {
   TournamentSimulateResponseSchema,
   CalculatePrizesRequestSchema,
   CalculatePrizesResponseSchema,
+  HotPatchLevelRequestSchema,
   TournamentScheduleRequestSchema,
   TournamentStateSchema,
   TournamentStatusSchema,
@@ -438,6 +441,7 @@ export type {
   TournamentSimulateResponse,
   CalculatePrizesRequest,
   CalculatePrizesResponse,
+  HotPatchLevelRequest,
   TournamentScheduleRequest,
   TournamentState,
   TournamentStatus,


### PR DESCRIPTION
## Summary
- allow bonus creation payloads to include optional claim counts and normalize nullable values safely
- rely on the helper output when creating bonuses and export hot patch level request types from shared schemas

## Testing
- npm test --prefix backend -- "bonus.helpers"


------
https://chatgpt.com/codex/tasks/task_e_68d7c3a24f688323b0c1fa8299ae1192