### PR TITLE
feat(analytics): align event schemas with typed consumers

### DIFF
--- a/backend/src/game/hand.controller.ts
+++ b/backend/src/game/hand.controller.ts
@@ -34,6 +34,7 @@ import type {
 import { HandLog } from './hand-log';
 import { sanitize } from './state-sanitize';
 import { GameStateSchema, type GameState } from '@shared/types';
+import { EVENT_SCHEMA_VERSION } from '@shared/events';
 
 interface JwtClaims extends JwtPayload {
   sub: string;
@@ -294,13 +295,11 @@ export class HandController {
     const sanitized = sanitize(state, userId);
     const { serverTime: _serverTime, ...sanitizedState } = sanitized;
 
-    const payload = {
-      version: '1',
+    return GameStateSchema.omit({ serverTime: true }).parse({
       ...sanitizedState,
       tick: index + 1,
-    };
-
-    return GameStateSchema.omit({ serverTime: true }).parse(payload);
+      version: EVENT_SCHEMA_VERSION,
+    });
   }
 
   @Get(':id/log')

--- a/backend/src/leaderboard/leaderboard.service.ts
+++ b/backend/src/leaderboard/leaderboard.service.ts
@@ -160,7 +160,7 @@ export class LeaderboardService implements OnModuleInit {
     const { days = 30, minSessions } = options;
     const since = Date.now() - days * DAY_MS;
     const events = await this.analytics.rangeStream(
-      'analytics:game',
+      'analytics:game.event',
       since,
       'game.event',
     );

--- a/backend/src/wallet/reconcile.job.ts
+++ b/backend/src/wallet/reconcile.job.ts
@@ -3,6 +3,7 @@ import path from 'path';
 import { Logger } from 'nestjs-pino';
 import { EventPublisher } from '../events/events.service';
 import { WalletService } from './wallet.service';
+import type { Events } from '@shared/events';
 
 export async function runReconcile(
   wallet: WalletService,
@@ -45,12 +46,12 @@ export async function runReconcile(
   const reportCount = report.length;
 
   if (reportCount > 0 || total !== 0) {
-    await events?.emit('wallet.reconcile.mismatch', {
+    const payload: Events['wallet.reconcile.mismatch'] = {
       date,
       total,
-      report,
-      reportCount,
-    });
+      ...(reportCount > 0 ? { report, reportCount } : {}),
+    };
+    await events?.emit('wallet.reconcile.mismatch', payload);
   }
 
   if (reportCount > 0 || total !== 0) {


### PR DESCRIPTION
## Summary
- introduce dedicated `game.analytics` and `tournament.analytics` schemas with shared typing and updated wallet mismatch metadata
- tighten analytics ingestion to parse events through the schema map and update collusion/leaderboard consumers to use the typed results
- harden game gateway state restoration and payload emission while keeping outbound frames typed and exposing chat messages

## Testing
- npm run build *(fails: existing frontend type errors – see terminal output for details)*

------
https://chatgpt.com/codex/tasks/task_e_68d7c3a6712c8323ac444b3bf1bcee0e