### PR TITLE
fix: ignore invalid bonus claim counters

### DIFF
--- a/backend/src/services/bonus.helpers.ts
+++ b/backend/src/services/bonus.helpers.ts
@@ -32,16 +32,12 @@ type BonusBaseFields = Pick<
   | 'status'
 >;
 
-function nullableNumber(value: unknown): number | null | undefined {
-  if (typeof value === 'number') {
-    return Number.isFinite(value) ? value : null;
+function nullableNumber(value: unknown): number | undefined {
+  if (typeof value !== 'number') {
+    return undefined;
   }
 
-  if (value === null) {
-    return null;
-  }
-
-  return undefined;
+  return Number.isFinite(value) ? value : undefined;
 }
 
 function mapBonusBaseFields(source: BonusBaseSource): BonusBaseFields {
@@ -89,7 +85,7 @@ export function toBonusEntityInput(
     const claimsTotal = nullableNumber(
       (payload as { claimsTotal?: unknown }).claimsTotal,
     );
-    if (claimsTotal !== undefined) {
+    if (typeof claimsTotal === 'number') {
       prepared.claimsTotal = claimsTotal;
     }
   }
@@ -97,7 +93,7 @@ export function toBonusEntityInput(
     const claimsWeek = nullableNumber(
       (payload as { claimsWeek?: unknown }).claimsWeek,
     );
-    if (claimsWeek !== undefined) {
+    if (typeof claimsWeek === 'number') {
       prepared.claimsWeek = claimsWeek;
     }
   }


### PR DESCRIPTION
## Summary
- treat bonus claim counters as undefined unless they are finite numbers
- only persist claimsTotal and claimsWeek when nullableNumber returns a number

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d7c9d8a73483238c31f72d30a3dde6