### PR TITLE
fix: expose list controller service injection

### DIFF
--- a/backend/src/common/controllers/list.controller.ts
+++ b/backend/src/common/controllers/list.controller.ts
@@ -20,7 +20,7 @@ export function createListController<
   @ApiTags(metadata.tag)
   @Controller(metadata.path)
   class ListController {
-    constructor(@Inject(Service) private readonly service: S) {}
+    constructor(@Inject(Service) readonly service: S) {}
 
     @Get()
     @ApiOperation({ summary: metadata.summary })


### PR DESCRIPTION
## Summary
- expose the injected service in the generated list controllers by making the constructor parameter public
- unblock compilation issues caused by private access on the service dependency

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7c9d9ad8c8323a9d6af80a0a65e8b