### PR TITLE
fix: align game state payload version handling

### DIFF
--- a/backend/src/game/state-sanitize.ts
+++ b/backend/src/game/state-sanitize.ts
@@ -1,5 +1,6 @@
-import type { InternalGameState } from './engine';
+import { EVENT_SCHEMA_VERSION } from '@shared/events';
 import type { GameState } from '@shared/types';
+import type { InternalGameState } from './engine';
 
 export function sanitize(
   state: InternalGameState,
@@ -7,7 +8,8 @@ export function sanitize(
 ): GameState {
   const { deck: _deck, players, ...rest } = state;
   return {
-    ...(rest as Omit<GameState, 'players' | 'serverTime'>),
+    ...(rest as Omit<GameState, 'players' | 'serverTime' | 'version'>),
+    version: EVENT_SCHEMA_VERSION,
     serverTime: Date.now(),
     players: players.map(({ id, stack, folded, bet, allIn, holeCards }) => ({
       id,


### PR DESCRIPTION
## Summary
- reuse the shared game state schema version literal in the gateway payload type
- tighten internal player validation and guard Redis pipeline responses before use
- stamp sanitized game state payloads with the event schema version instead of duplicating spreads

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d7c9d75e588323a83465893b9d2070