### PR TITLE
fix(api): align bank reconciliation upload type with express v5

### DIFF
--- a/backend/src/routes/bank-reconciliation.controller.ts
+++ b/backend/src/routes/bank-reconciliation.controller.ts
@@ -24,7 +24,7 @@ import {
 } from '@shared/wallet.schema';
 import { MessageResponseSchema } from '../schemas/auth';
 import { API_CONTRACT_VERSION } from '@shared/constants';
-import type { Express } from 'express';
+import type { Request } from 'express';
 
 @ApiTags('admin')
 @UseGuards(AuthGuard, AdminGuard)
@@ -71,7 +71,7 @@ export class BankReconciliationController {
   })
   @ApiResponse({ status: 200, description: 'Reconciliation completed' })
   async reconcile(
-    @UploadedFile() file: Express.Multer.File | undefined,
+    @UploadedFile() file: Request['file'],
     @Body() body: BankReconciliationRequest | any,
   ) {
     if (file) {


### PR DESCRIPTION
## Summary
- replace the Express.Multer.File annotation with the Express Request file type so the upload decorator compiles under Express v5 types

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d7cdf52e2883239da9b47126549680