### PR TITLE
fix: type uploaded file in bank reconciliation controller

### DIFF
--- a/backend/src/routes/bank-reconciliation.controller.ts
+++ b/backend/src/routes/bank-reconciliation.controller.ts
@@ -24,7 +24,7 @@ import {
 } from '@shared/wallet.schema';
 import { MessageResponseSchema } from '../schemas/auth';
 import { API_CONTRACT_VERSION } from '@shared/constants';
-import type { Request } from 'express';
+import type { Express } from 'express';
 
 @ApiTags('admin')
 @UseGuards(AuthGuard, AdminGuard)
@@ -71,7 +71,7 @@ export class BankReconciliationController {
   })
   @ApiResponse({ status: 200, description: 'Reconciliation completed' })
   async reconcile(
-    @UploadedFile() file: Request['file'],
+    @UploadedFile() file: Express.Multer.File | undefined,
     @Body() body: BankReconciliationRequest | any,
   ) {
     if (file) {


### PR DESCRIPTION
## Summary
- type the uploaded file parameter in the bank reconciliation controller as an Express Multer file to align with Nest's typings

## Testing
- npm run build --prefix backend

------
https://chatgpt.com/codex/tasks/task_e_68d7cea7e0988323bb414d274e5a38fb