### PR TITLE
fix: rely on global Express namespace for multer types

### DIFF
--- a/backend/src/routes/bank-reconciliation.controller.ts
+++ b/backend/src/routes/bank-reconciliation.controller.ts
@@ -24,7 +24,6 @@ import {
 } from '@shared/wallet.schema';
 import { MessageResponseSchema } from '../schemas/auth';
 import { API_CONTRACT_VERSION } from '@shared/constants';
-import type { Express } from 'express';
 import 'multer';
 
 @ApiTags('admin')


### PR DESCRIPTION
## Summary
- remove the explicit Express type import that shadowed the global namespace augmentation
- rely on the multer augmentation to expose Express.Multer.File without build errors

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d7d093e7f08323aa67ada1b4e3dbea