### PR TITLE
fix(api): correct multer file typing in bank reconciliation controller

### DIFF
--- a/backend/src/routes/bank-reconciliation.controller.ts
+++ b/backend/src/routes/bank-reconciliation.controller.ts
@@ -24,7 +24,7 @@ import {
 } from '@shared/wallet.schema';
 import { MessageResponseSchema } from '../schemas/auth';
 import { API_CONTRACT_VERSION } from '@shared/constants';
-import type { Express } from 'express';
+import type { Request } from 'express';
 import 'multer';
 
 @ApiTags('admin')
@@ -72,7 +72,7 @@ export class BankReconciliationController {
   })
   @ApiResponse({ status: 200, description: 'Reconciliation completed' })
   async reconcile(
-    @UploadedFile() file: Express.Multer.File | undefined,
+    @UploadedFile() file: Request['file'],
     @Body() body: BankReconciliationRequest | any,
   ) {
     if (file) {


### PR DESCRIPTION
## Summary
- align the bank reconciliation controller's uploaded file parameter with Express' Request typing to avoid missing namespace errors

## Testing
- npm run build (backend)


------
https://chatgpt.com/codex/tasks/task_e_68d7d093e7f08323aa67ada1b4e3dbea