### PR TITLE
fix(api): build backend before starting server

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "build": "nest build",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
-    "start": "nest start",
+    "start": "nest start --build",
     "start:dev": "nest start --watch",
     "start:debug": "nest start --debug --watch",
     "start:prod": "node dist/main",


### PR DESCRIPTION
## Summary
- ensure the standard start script triggers a compilation before launching NestJS so dist/main exists

## Testing
- npm run start (manually interrupted after verifying build)


------
https://chatgpt.com/codex/tasks/task_e_68d7d37154688323aedc9ce296183f77