### PR TITLE
infra(k8s): configure backend redis connection

### DIFF
--- a/infra/k8s/api-deployment.yaml
+++ b/infra/k8s/api-deployment.yaml
@@ -29,6 +29,8 @@ spec:
                   key: REPLICA_ENDPOINT
             - name: DB_FAILOVER_STRATEGY
               value: promote-replica
+            - name: REDIS_URL
+              value: redis://redis:6379
             - name: ALERTMANAGER_URL
               value: http://alertmanager:9093
           resources:


### PR DESCRIPTION
## Summary
- set the API deployment's REDIS_URL so the backend connects to the cluster redis service

## Testing
- not run (infrastructure configuration change)


------
https://chatgpt.com/codex/tasks/task_e_68d7ff95b7ac8323a60d6edafc69a123