### PR TITLE
fix: require kafka broker configuration

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -16,5 +16,6 @@ PAYMENT_PROVIDER_BASE_URL=https://api.stripe.com/v1
 DEFAULT_CURRENCY=usd
 
 # Analytics service
-KAFKA_BROKERS=kafka:9092
+# Comma-separated bootstrap brokers (host:port)
+KAFKA_BROKERS=kafka-1:9092,kafka-2:9092
 CLICKHOUSE_URL=http://clickhouse:8123


### PR DESCRIPTION
## Summary
- throw when analytics Kafka brokers are missing so we no longer return the noop client
- allow injecting a Kafka factory for tests and expose broker parsing helpers
- document the expected comma-separated broker list in the backend env example

## Testing
- npm test -- --runTestsByPath test/common/kafka.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68d7ff9675b08323913acc06f4d767ef