### PR TITLE
fix: register metric readers with the meter provider

### DIFF
--- a/shared/telemetry/index.ts
+++ b/shared/telemetry/index.ts
@@ -147,7 +147,10 @@ export async function setupTelemetry({
       );
     }
 
-    meterProvider = new MeterProvider({ resource, readers: metricReaders });
+    meterProvider = new MeterProvider({ resource });
+    for (const reader of metricReaders) {
+      meterProvider.addMetricReader(reader);
+    }
     metrics.setGlobalMeterProvider(meterProvider);
   }
 


### PR DESCRIPTION
## Summary
- create the MeterProvider with the resource only and register metric readers via addMetricReader to align with updated OpenTelemetry types

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d8059d5c188323b46c3084ec14e824