### PR TITLE
fix: resolve postgres url credentials from env

### DIFF
--- a/backend/src/config/database-url.ts
+++ b/backend/src/config/database-url.ts
@@ -1,0 +1,97 @@
+import fs from 'node:fs';
+
+type Nullable<T> = T | undefined | null;
+
+const readEnv = (key: string): string | undefined => {
+  const direct = process.env[key];
+  if (direct && direct.trim().length > 0) {
+    return direct.trim();
+  }
+
+  const fileKey = `${key}_FILE`;
+  const filePath = process.env[fileKey];
+
+  if (!filePath) {
+    return undefined;
+  }
+
+  try {
+    return fs.readFileSync(filePath, 'utf8').trim();
+  } catch (error) {
+    const message =
+      error instanceof Error && error.message
+        ? error.message
+        : 'unknown error while reading secret file';
+    throw new Error(`Failed to read ${fileKey}=${filePath}: ${message}`);
+  }
+};
+
+const coerceString = (value: Nullable<string>): string | undefined => {
+  if (value == null) {
+    return undefined;
+  }
+  const trimmed = `${value}`.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+};
+
+export const resolveDatabaseUrl = (): string => {
+  const explicitUrl = coerceString(readEnv('DATABASE_URL'));
+
+  const fallbackHost = coerceString(readEnv('DB_HOST')) ?? 'localhost';
+  const fallbackPort =
+    coerceString(readEnv('DB_HOST_PORT')) ??
+    coerceString(readEnv('DB_PORT')) ??
+    '15432';
+  const fallbackUser = coerceString(readEnv('DB_USER')) ?? 'postgres';
+  const fallbackPassword = coerceString(readEnv('DB_PASS')) ??
+    coerceString(readEnv('DB_PASSWORD')) ??
+    coerceString(readEnv('POSTGRES_PASSWORD'));
+  const fallbackDatabase = coerceString(readEnv('DB_NAME')) ?? 'pokerhub';
+
+  if (explicitUrl) {
+    try {
+      const url = new URL(explicitUrl);
+
+      if (!url.username && fallbackUser) {
+        url.username = fallbackUser;
+      }
+
+      if (!url.password) {
+        if (fallbackPassword) {
+          url.password = fallbackPassword;
+        } else {
+          throw new Error(
+            'DATABASE_URL is missing a password. Provide it in the URL or via DB_PASS/DB_PASSWORD/POSTGRES_PASSWORD.',
+          );
+        }
+      }
+
+      if (!url.hostname) {
+        url.hostname = fallbackHost;
+      }
+
+      if (!url.port && fallbackPort) {
+        url.port = fallbackPort;
+      }
+
+      if (!url.pathname || url.pathname === '/') {
+        url.pathname = `/${fallbackDatabase}`;
+      }
+
+      return url.toString();
+    } catch (error) {
+      const message =
+        error instanceof Error && error.message
+          ? error.message
+          : 'Unknown error while parsing DATABASE_URL';
+      throw new Error(`Invalid DATABASE_URL provided: ${message}`);
+    }
+  }
+
+  const password = fallbackPassword ?? 'postgres';
+
+  return `postgres://${encodeURIComponent(fallbackUser)}:${encodeURIComponent(
+    password,
+  )}@${fallbackHost}:${fallbackPort}/${fallbackDatabase}`;
+};
+

--- a/backend/src/config/database.config.ts
+++ b/backend/src/config/database.config.ts
@@ -1,12 +1,10 @@
 import { registerAs } from '@nestjs/config';
 
-export default registerAs('database', () => {
-  const localPort = process.env.DB_HOST_PORT ?? process.env.DB_PORT ?? '15432';
+import { resolveDatabaseUrl } from './database-url';
 
+export default registerAs('database', () => {
   return {
-    url:
-      process.env.DATABASE_URL ??
-      `postgres://postgres:postgres@localhost:${localPort}/pokerhub`,
+    url: resolveDatabaseUrl(),
     synchronize: process.env.DB_SYNC === 'true',
   };
 });

--- a/backend/src/database/data-source.ts
+++ b/backend/src/database/data-source.ts
@@ -32,10 +32,11 @@ import { TournamentDetail } from '../tournament/tournament-detail.entity';
 import { PerformanceThresholdEntity } from './entities/performance-threshold.entity';
 import { TournamentFormatEntity } from '../tournament/tournament-format.entity';
 import { AdminTournamentFilterEntity } from '../tournament/admin-tournament-filter.entity';
+import { resolveDatabaseUrl } from '../config/database-url';
 
 export const AppDataSource = new DataSource({
   type: 'postgres',
-  url: process.env.DATABASE_URL,
+  url: resolveDatabaseUrl(),
   entities: [
     User,
     Tournament,


### PR DESCRIPTION
## Summary
- add a shared resolver that builds the Postgres connection URL from env vars and secret files
- reuse the resolver for the Nest config and TypeORM data source so migrations fail early when a password is missing

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d80c18406c8323be84b6679b0042c6