### PR TITLE
fix: guard nav save result type

### DIFF
--- a/backend/src/nav/nav.service.ts
+++ b/backend/src/nav/nav.service.ts
@@ -25,6 +25,9 @@ export class NavService {
   async create(item: NavItemRequest): Promise<NavItem> {
     const entity = this.repo.create(item);
     const saved = await this.repo.save(entity);
+    if (Array.isArray(saved)) {
+      throw new Error('Unexpected array');
+    }
     const { flag, href, label, icon, order } = saved;
     return { flag, href, label, order, ...(icon ? { icon } : {}) };
   }
@@ -34,6 +37,9 @@ export class NavService {
     if (!existing) throw new NotFoundException('Nav item not found');
     const merged = { ...existing, ...item };
     const saved = await this.repo.save(merged);
+    if (Array.isArray(saved)) {
+      throw new Error('Unexpected array');
+    }
     const { href, label, icon, order: savedOrder } = saved;
     return {
       flag: saved.flag,


### PR DESCRIPTION
## Summary
- ensure nav service guards against array returns from TypeORM save
- keep create and update methods narrowed to single NavItemEntity when destructuring

## Testing
- npm run build --prefix backend

------
https://chatgpt.com/codex/tasks/task_e_68d822978d70832388510f2f040483a3