### PR TITLE
fix(backend): type json schema for analytics validator

### DIFF
--- a/backend/src/analytics/validator.ts
+++ b/backend/src/analytics/validator.ts
@@ -2,6 +2,7 @@ import Ajv, { ValidateFunction } from 'ajv';
 import addFormats from 'ajv-formats';
 import { zodToJsonSchema } from 'zod-to-json-schema';
 import { EventSchemas, EventName } from '@shared/events';
+import type { JSONSchema7 } from 'json-schema';
 
 export function createValidators(): {
   ajv: Ajv;
@@ -15,7 +16,8 @@ export function createValidators(): {
   );
   const validators = {} as Record<EventName, ValidateFunction>;
   for (const [name, schema] of Object.entries(EventSchemas)) {
-    validators[name as EventName] = ajv.compile(zodToJsonSchema(schema, name));
+    const jsonSchema = zodToJsonSchema(schema, name) as JSONSchema7;
+    validators[name as EventName] = ajv.compile(jsonSchema);
   }
   return { ajv, validators };
 }


### PR DESCRIPTION
## Summary
- import JSONSchema7 to type conversions from zod schema
- reuse compiled json schema variable before invoking ajv.compile

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d8229f9d448323b391ffb9d188158e