### PR TITLE
chore: mount shared contract volumes for backend

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -4,6 +4,8 @@ services:
       - "${BACKEND_PORT:-3000}:3000"
     volumes:
       - ./backend:/app
+      - ./shared:/shared
+      - ./contracts:/contracts
     environment:
       - DATABASE_URL=${DATABASE_URL}
       - REDIS_URL=${REDIS_URL}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,8 @@ services:
       - CLICKHOUSE_URL=${CLICKHOUSE_URL}
     volumes:
       - ${GOOGLE_APPLICATION_CREDENTIALS}:/secrets/gcp-service-account.json:ro
+      - ./shared:/shared
+      - ./contracts:/contracts
     depends_on:
       db:
         condition: service_healthy


### PR DESCRIPTION
## Summary
- mount the shared and contracts directories inside the backend container when using the override compose file
- mirror the same shared and contract mounts in the base compose definition for non-override runs

## Testing
- docker compose down backend *(fails in CI image: `docker` not available)*
- docker compose up backend *(fails in CI image: `docker` not available)*

------
https://chatgpt.com/codex/tasks/task_e_68d822a088f883239eae2ae6236bb01f