### PR TITLE
fix: mount backend source in compose dev backend

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,7 @@ services:
       - CLICKHOUSE_URL=${CLICKHOUSE_URL}
     volumes:
       - ${GOOGLE_APPLICATION_CREDENTIALS}:/secrets/gcp-service-account.json:ro
+      - ./backend:/backend
       - ./shared:/shared
       - ./contracts:/contracts
     depends_on:


### PR DESCRIPTION
## Summary
- bind mount the backend source into the backend service container so tools can resolve /backend paths

## Testing
- npm run start:dev (backend)


------
https://chatgpt.com/codex/tasks/task_e_68d82526da50832391b772ccd910c23c