### PR TITLE
chore: promote runtime schema dependencies

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -69,6 +69,7 @@
         "rxjs": "^7.8.1",
         "socket.io": "^4.8.1",
         "typeorm": "^0.3.26",
+        "zod": "^3.25.76",
         "zod-to-json-schema": "^3.24.6"
       },
       "devDependencies": {
@@ -101,12 +102,15 @@
         "tsconfig-paths": "^4.2.0",
         "typescript": "^5.7.3",
         "typescript-eslint": "^8.20.0",
-        "zod": "^3.25.76",
         "zod-fast-check": "^0.10.1"
       }
     },
     "..": {
       "version": "1.0.0",
+      "dependencies": {
+        "js-sha256": "^0.11.0",
+        "zod": "^3.25.76"
+      },
       "bin": {
         "verify": "bin/verify"
       },
@@ -130,7 +134,6 @@
         "eslint-plugin-unused-imports": "^4.1.2",
         "express": "^4.18.2",
         "fast-check": "^3.23.2",
-        "js-sha256": "^0.11.0",
         "jscpd": "^4.0.5",
         "openapi-fetch": "^0.7.10",
         "openapi-typescript": "^6.7.0",
@@ -142,8 +145,7 @@
         "ts-prune": "^0.10.3",
         "typescript": "^5.7.3",
         "typescript-eslint": "^8.20.0",
-        "ws": "^8.18.0",
-        "zod": "^3.25.76"
+        "ws": "^8.18.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -91,6 +91,7 @@
     "rxjs": "^7.8.1",
     "socket.io": "^4.8.1",
     "typeorm": "^0.3.26",
+    "zod": "^3.25.76",
     "zod-to-json-schema": "^3.24.6"
   },
   "devDependencies": {
@@ -123,7 +124,6 @@
     "tsconfig-paths": "^4.2.0",
     "typescript": "^5.7.3",
     "typescript-eslint": "^8.20.0",
-    "zod": "^3.25.76",
     "zod-fast-check": "^0.10.1"
   },
   "jest": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,10 @@
     "": {
       "name": "pokerhub",
       "version": "1.0.0",
+      "dependencies": {
+        "js-sha256": "^0.11.0",
+        "zod": "^3.25.76"
+      },
       "bin": {
         "verify": "bin/verify"
       },
@@ -30,7 +34,6 @@
         "eslint-plugin-unused-imports": "^4.1.2",
         "express": "^4.18.2",
         "fast-check": "^3.23.2",
-        "js-sha256": "^0.11.0",
         "jscpd": "^4.0.5",
         "openapi-fetch": "^0.7.10",
         "openapi-typescript": "^6.7.0",
@@ -42,8 +45,7 @@
         "ts-prune": "^0.10.3",
         "typescript": "^5.7.3",
         "typescript-eslint": "^8.20.0",
-        "ws": "^8.18.0",
-        "zod": "^3.25.76"
+        "ws": "^8.18.0"
       }
     },
     "node_modules/@actions/github": {
@@ -5296,7 +5298,6 @@
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.11.1.tgz",
       "integrity": "sha512-o6WSo/LUvY2uC4j7mO50a2ms7E/EAdbP0swigLV+nzHKTTaYnaLIWJ02VdXrsJX0vGedDESQnLsOekr94ryfjg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-stringify": {
@@ -9889,7 +9890,6 @@
       "version": "3.25.76",
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "eslint-plugin-unused-imports": "^4.1.2",
     "express": "^4.18.2",
     "fast-check": "^3.23.2",
-    "js-sha256": "^0.11.0",
     "jscpd": "^4.0.5",
     "openapi-fetch": "^0.7.10",
     "openapi-typescript": "^6.7.0",
@@ -67,7 +66,10 @@
     "ts-prune": "^0.10.3",
     "typescript": "^5.7.3",
     "typescript-eslint": "^8.20.0",
-    "ws": "^8.18.0",
+    "ws": "^8.18.0"
+  },
+  "dependencies": {
+    "js-sha256": "^0.11.0",
     "zod": "^3.25.76"
   }
 }


### PR DESCRIPTION
## Summary
- move zod and js-sha256 into runtime dependencies at the repo root so shared modules resolve in production
- mirror the zod dependency under backend dependencies and refresh both lockfiles after installing

## Testing
- npm install
- npm install --prefix backend
- npm run build --prefix backend

------
https://chatgpt.com/codex/tasks/task_e_68d82527cdac8323ac753a86dff3292c