### PR TITLE
chore: share root deps with backend compose

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -6,6 +6,7 @@ services:
       - ./backend:/app
       - ./shared:/shared
       - ./contracts:/contracts
+      - ./node_modules:/node_modules
     environment:
       - DATABASE_URL=${DATABASE_URL}
       - REDIS_URL=${REDIS_URL}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,7 @@ services:
       - ./backend:/backend
       - ./shared:/shared
       - ./contracts:/contracts
+      - ./node_modules:/node_modules
     depends_on:
       db:
         condition: service_healthy

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "@opentelemetry/sdk-metrics": "2.1.0",
     "@opentelemetry/sdk-node": "0.205.0",
     "@opentelemetry/semantic-conventions": "1.37.0",
+    "@types/express": "^4.17.21",
     "depcheck": "^1.4.7",
     "eslint": "^9.18.0",
     "eslint-plugin-unused-imports": "^4.1.2",


### PR DESCRIPTION
## Summary
- add the Express type definitions to the root devDependencies for shared telemetry builds
- bind-mount the root node_modules into the backend containers so shared packages resolve

## Testing
- docker compose up backend --build *(fails: docker not available in execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d82b5d32cc83238f748d33e2d944f4