### PR TITLE
fix(backend): wait for compiled entry before bootstrapping

### DIFF
--- a/backend/scripts/prepare-dist-entry.js
+++ b/backend/scripts/prepare-dist-entry.js
@@ -23,11 +23,30 @@ const relativeRequirePath = path
   .relative(path.dirname(outputMain), compiledMain)
   .replace(/\\\\/g, '/');
 
-const bootstrapStub = `const sdkMetrics = require("@opentelemetry/sdk-metrics");\n` +
+const waitForCompiledMain = allowMissing
+  ? `const fs = require("node:fs");\n` +
+    `const path = require("node:path");\n` +
+    `const compiledMain = path.join(__dirname, ${JSON.stringify(relativeRequirePath)});\n` +
+    `if (!fs.existsSync(compiledMain)) {\n` +
+    `  const timeoutMs = parseInt(process.env.POKERHUB_COMPILED_MAIN_TIMEOUT_MS ?? "30000", 10);\n` +
+    `  const start = Date.now();\n` +
+    `  while (!fs.existsSync(compiledMain)) {\n` +
+    `    if (Date.now() - start > timeoutMs) {\n` +
+    `      throw new Error(\"Timed out waiting for compiled entry point at \\${compiledMain}\");\n` +
+    `    }\n` +
+    `    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 100);\n` +
+    `  }\n` +
+    `}\n`
+  : `const path = require("node:path");\n` +
+    `const compiledMain = path.join(__dirname, ${JSON.stringify(relativeRequirePath)});\n`;
+
+const bootstrapStub =
+  `const sdkMetrics = require("@opentelemetry/sdk-metrics");\n` +
   `if (!sdkMetrics.AggregationType) {\n` +
   `  sdkMetrics.AggregationType = Object.freeze({ DEFAULT: "DEFAULT" });\n` +
   `}\n` +
-  `module.exports = require("./${relativeRequirePath}");\n`;
+  waitForCompiledMain +
+  `module.exports = require(compiledMain);\n`;
 
 fs.mkdirSync(path.dirname(outputMain), { recursive: true });
 fs.writeFileSync(outputMain, bootstrapStub);


### PR DESCRIPTION
## Summary
- wait for the compiled Nest entry file before bootstrapping the dist stub so watch mode does not crash
- allow configuring the wait timeout with `POKERHUB_COMPILED_MAIN_TIMEOUT_MS`

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d82eb10184832385806d51ae4281f8