### PR TITLE
Fix backend dev server module resolution for shared packages

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -55,6 +55,7 @@
         "ioredis": "^5.7.0",
         "ioredis-mock": "^8.12.1",
         "joi": "^18.0.1",
+        "js-sha256": "^0.11.0",
         "jsonwebtoken": "^9.0.2",
         "kafkajs": "^2.2.4",
         "nestjs-pino": "^4.4.0",
@@ -129,6 +130,7 @@
         "@opentelemetry/sdk-metrics": "2.1.0",
         "@opentelemetry/sdk-node": "0.205.0",
         "@opentelemetry/semantic-conventions": "1.37.0",
+        "@types/express": "^4.17.21",
         "depcheck": "^1.4.7",
         "eslint": "^9.18.0",
         "eslint-plugin-unused-imports": "^4.1.2",
@@ -12860,6 +12862,12 @@
       "engines": {
         "node": ">= 20"
       }
+    },
+    "node_modules/js-sha256": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.11.1.tgz",
+      "integrity": "sha512-o6WSo/LUvY2uC4j7mO50a2ms7E/EAdbP0swigLV+nzHKTTaYnaLIWJ02VdXrsJX0vGedDESQnLsOekr94ryfjg==",
+      "license": "MIT"
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -78,6 +78,7 @@
     "ioredis-mock": "^8.12.1",
     "joi": "^18.0.1",
     "jsonwebtoken": "^9.0.2",
+    "js-sha256": "^0.11.0",
     "kafkajs": "^2.2.4",
     "nestjs-pino": "^4.4.0",
     "onfido": "^4.3.0",

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -13,7 +13,7 @@
     "target": "ES2023",
     "sourceMap": true,
     "outDir": "./dist",
-    "baseUrl": "./",
+    "baseUrl": "../",
     "typeRoots": ["src/@types", "node_modules/@types", "../contracts/types"],
     "incremental": true,
     "skipLibCheck": true,
@@ -24,8 +24,9 @@
     "noFallthroughCasesInSwitch": false,
     "resolveJsonModule": true,
     "paths": {
-      "@shared/*": ["../shared/*"],
-      "@contracts/*": ["../contracts/types/*"]
+      "@shared/*": ["shared/*"],
+      "@contracts/*": ["contracts/types/*"],
+      "*": ["backend/node_modules/*", "node_modules/*"]
     }
   }
 }


### PR DESCRIPTION
## Summary
- point the backend TypeScript compiler at the monorepo root so shared source files resolve dependencies correctly during watch mode
- add a catch-all module path fallback and include js-sha256 in backend dependencies to satisfy shared imports

## Testing
- npm run build --prefix backend
- npm run start:dev --prefix backend

------
https://chatgpt.com/codex/tasks/task_e_68d8305e02f48323ae13622e51ebbc65