### PR TITLE
fix(backend): load crypto shim before module init

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -1,3 +1,5 @@
+import './shims/crypto';
+
 import { Logger, Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { DataSource, type DataSourceOptions } from 'typeorm';


### PR DESCRIPTION
## Summary
- import the crypto shim in the Nest application module so the global randomUUID polyfill is applied before TypeORM initializes

## Testing
- npm --prefix backend run build

------
https://chatgpt.com/codex/tasks/task_e_68d8d7f46eb4832393f3a95905198603