### PR TITLE
test(tournament): use helper for TournamentService setup

### DIFF
--- a/backend/test/tournament/balancer.repeat-move.property.spec.ts
+++ b/backend/test/tournament/balancer.repeat-move.property.spec.ts
@@ -1,18 +1,9 @@
 import fc from 'fast-check';
 import { TableBalancerService } from '../../src/tournament/table-balancer.service';
-import { TournamentService } from '../../src/tournament/tournament.service';
+import { createTournamentServiceInstance } from './helpers';
 
 describe('table balancer repeat move property', () => {
-  const realTournament = new TournamentService(
-    {} as any,
-    {} as any,
-    {} as any,
-    {} as any,
-    {} as any,
-    {} as any,
-    {} as any,
-    {} as any,
-  );
+  const realTournament = createTournamentServiceInstance();
 
   it('avoids moving the same player twice within N hands', async () => {
     await fc.assert(

--- a/backend/test/tournament/bubble-resolution.spec.ts
+++ b/backend/test/tournament/bubble-resolution.spec.ts
@@ -1,17 +1,7 @@
-import { TournamentService } from '../../src/tournament/tournament.service';
-import { RebuyService } from '../../src/tournament/rebuy.service';
-import { PkoService } from '../../src/tournament/pko.service';
+import { createTournamentServiceInstance } from './helpers';
 
 describe('Bubble resolution', () => {
-  const service = new TournamentService(
-    {} as any,
-    {} as any,
-    {} as any,
-    {} as any,
-    { get: jest.fn() } as any,
-    new RebuyService(),
-    new PkoService(),
-  );
+  const service = createTournamentServiceInstance();
 
   it('awards odd chips to larger stacks', () => {
     const busts = [

--- a/backend/test/tournament/last-moved-hand.spec.ts
+++ b/backend/test/tournament/last-moved-hand.spec.ts
@@ -1,13 +1,15 @@
 import { TableBalancerService } from '../../src/tournament/table-balancer.service';
-import { TournamentService } from '../../src/tournament/tournament.service';
 import { Table } from '../../src/database/entities/table.entity';
 import { Seat } from '../../src/database/entities/seat.entity';
 import {
   Tournament,
   TournamentState,
 } from '../../src/database/entities/tournament.entity';
-import { Repository } from 'typeorm';
-import { createSeatRepo, createTournamentRepo } from './helpers';
+import {
+  createSeatRepo,
+  createTournamentRepo,
+  createTournamentServiceInstance,
+} from './helpers';
 
 describe('TableBalancerService lastMovedHand persistence', () => {
   it('skips moves for players who recently moved even after restart', async () => {
@@ -53,13 +55,13 @@ describe('TableBalancerService lastMovedHand persistence', () => {
     ]);
     const scheduler: any = {};
     const rooms: any = { get: jest.fn() };
-    const service = new TournamentService(
+    const service = createTournamentServiceInstance({
       tournamentsRepo,
       seatsRepo,
       tablesRepo,
       scheduler,
       rooms,
-    );
+    });
     const balancer = new TableBalancerService(tablesRepo, service);
 
     await balancer.rebalanceIfNeeded('t1', 10, 5);
@@ -82,13 +84,13 @@ describe('TableBalancerService lastMovedHand persistence', () => {
     });
 
     // simulate service restart
-    const service2 = new TournamentService(
+    const service2 = createTournamentServiceInstance({
       tournamentsRepo,
       seatsRepo,
       tablesRepo,
       scheduler,
       rooms,
-    );
+    });
     const balancer2 = new TableBalancerService(tablesRepo, service2);
 
     await balancer2.rebalanceIfNeeded('t1', 11, 5);

--- a/backend/test/tournament/manage-seat.spec.ts
+++ b/backend/test/tournament/manage-seat.spec.ts
@@ -1,4 +1,4 @@
-import { TournamentService } from '../../src/tournament/tournament.service';
+import type { TournamentService } from '../../src/tournament/tournament.service';
 import {
   Tournament,
   TournamentState,
@@ -6,8 +6,7 @@ import {
 import { Seat } from '../../src/database/entities/seat.entity';
 import { Table } from '../../src/database/entities/table.entity';
 import { Repository } from 'typeorm';
-import { RebuyService } from '../../src/tournament/rebuy.service';
-import { PkoService } from '../../src/tournament/pko.service';
+import { createTournamentServiceInstance } from './helpers';
 
 interface SetupTournamentServiceOptions {
   useTransactionManager?: boolean;
@@ -90,22 +89,16 @@ function setupTournamentService({
   const flags = {};
   const events = { emit: jest.fn() } as any;
 
-  const service = new TournamentService(
-    tournamentsRepo as unknown as Repository<Tournament>,
-    seatRepo as unknown as Repository<Seat>,
-    tablesRepo as unknown as Repository<Table>,
-    scheduler as any,
-    rooms as any,
-    new RebuyService(),
-    new PkoService(),
-    flags as any,
+  const service = createTournamentServiceInstance({
+    tournamentsRepo: tournamentsRepo as unknown as Repository<Tournament>,
+    seatsRepo: seatRepo as unknown as Repository<Seat>,
+    tablesRepo: tablesRepo as unknown as Repository<Table>,
+    scheduler: scheduler as any,
+    rooms: rooms as any,
+    flags: flags as any,
     events,
-    undefined,
-    undefined,
-    undefined,
-    undefined,
-    wallet as any,
-  );
+    wallet: wallet as any,
+  });
 
   if (useTransactionManager) {
     const txManager: TransactionManagerMocks = {

--- a/backend/test/tournament/mega-sim.spec.ts
+++ b/backend/test/tournament/mega-sim.spec.ts
@@ -1,13 +1,11 @@
 import fs from 'fs';
 import path from 'path';
 import { TableBalancerService } from '../../src/tournament/table-balancer.service';
-import { TournamentService } from '../../src/tournament/tournament.service';
-import { RebuyService } from '../../src/tournament/rebuy.service';
-import { PkoService } from '../../src/tournament/pko.service';
 import { calculateIcmPayouts } from '@shared/utils/icm';
 import { Seat } from '../../src/database/entities/seat.entity';
 import { Table } from '../../src/database/entities/table.entity';
 import { Tournament } from '../../src/database/entities/tournament.entity';
+import { createTournamentServiceInstance } from './helpers';
 
 async function runSimulation(players: number, checkIcm = false): Promise<number> {
   const start = Date.now();
@@ -61,17 +59,15 @@ async function runSimulation(players: number, checkIcm = false): Promise<number>
   const flags: any = { get: async () => true, getTourney: async () => true };
   const events: any = { emit: async () => {} };
 
-  const service = new TournamentService(
+  const service = createTournamentServiceInstance({
     tournamentsRepo,
     seatsRepo,
     tablesRepo,
     scheduler,
     rooms,
-    new RebuyService(),
-    new PkoService(),
     flags,
     events,
-  );
+  });
   const balancer = new TableBalancerService(tablesRepo, service);
 
   await service.scheduleTournament('t1', {

--- a/backend/test/tournament/payout-distribution.spec.ts
+++ b/backend/test/tournament/payout-distribution.spec.ts
@@ -1,17 +1,7 @@
-import { TournamentService } from '../../src/tournament/tournament.service';
-import { RebuyService } from '../../src/tournament/rebuy.service';
-import { PkoService } from '../../src/tournament/pko.service';
+import { createTournamentServiceInstance } from './helpers';
 
 describe('Payout distribution', () => {
-  const service = new TournamentService(
-    {} as any,
-    {} as any,
-    {} as any,
-    {} as any,
-    { get: jest.fn() } as any,
-    new RebuyService(),
-    new PkoService(),
-  );
+  const service = createTournamentServiceInstance();
 
   it('ICM pays all remaining players compared to top-N', () => {
     const stacks = [5000, 3000, 2000, 1000];

--- a/backend/test/tournament/payout.spec.ts
+++ b/backend/test/tournament/payout.spec.ts
@@ -1,19 +1,8 @@
-import { TournamentService } from '../../src/tournament/tournament.service';
-import { RebuyService } from '../../src/tournament/rebuy.service';
-import { PkoService } from '../../src/tournament/pko.service';
+import { createTournamentServiceInstance } from './helpers';
 import { icmRaw } from '@shared/utils/icm';
 
 describe('ICM payout accuracy', () => {
-  const service = new TournamentService(
-    {} as any,
-    {} as any,
-    {} as any,
-    {} as any,
-    {} as any,
-    new RebuyService(),
-    new PkoService(),
-    { get: jest.fn() } as any,
-  );
+  const service = createTournamentServiceInstance();
 
   function icmHelper(stacks: number[], payouts: number[]): number[] {
     return icmRaw(stacks, payouts);

--- a/backend/test/tournament/payouts.spec.ts
+++ b/backend/test/tournament/payouts.spec.ts
@@ -1,20 +1,9 @@
 import fc from 'fast-check';
-import { TournamentService } from '../../src/tournament/tournament.service';
-import { RebuyService } from '../../src/tournament/rebuy.service';
-import { PkoService } from '../../src/tournament/pko.service';
+import { createTournamentServiceInstance } from './helpers';
 import { icmRaw } from '@shared/utils/icm';
 
 describe('tournament calculatePrizes property', () => {
-  const service = new TournamentService(
-    {} as any,
-    {} as any,
-    {} as any,
-    {} as any,
-    {} as any,
-    new RebuyService(),
-    new PkoService(),
-    { get: jest.fn().mockResolvedValue(true) } as any,
-  );
+  const service = createTournamentServiceInstance();
 
   it('conserves prize pool and limits rounding error', () => {
     fc.assert(

--- a/backend/test/tournament/scheduler.spec.ts
+++ b/backend/test/tournament/scheduler.spec.ts
@@ -1,12 +1,10 @@
 import { TournamentScheduler } from '../../src/tournament/scheduler.service';
 import { TableBalancerService } from '../../src/tournament/table-balancer.service';
-import { TournamentService } from '../../src/tournament/tournament.service';
 import { Table } from '../../src/database/entities/table.entity';
 import { Seat } from '../../src/database/entities/seat.entity';
 import { Tournament } from '../../src/database/entities/tournament.entity';
-import { RebuyService } from '../../src/tournament/rebuy.service';
-import { PkoService } from '../../src/tournament/pko.service';
 import { icmRaw } from '@shared/utils/icm';
+import { createTournamentServiceInstance } from './helpers';
 
 describe('TournamentScheduler', () => {
   it('schedules level up jobs', async () => {
@@ -127,16 +125,13 @@ describe('TournamentScheduler', () => {
     };
 
     const rooms: any = { get: jest.fn() };
-    const service = new TournamentService(
-      serviceDeps.tournaments,
-      serviceDeps.seats,
-      serviceDeps.tables,
+    const service = createTournamentServiceInstance({
+      tournamentsRepo: serviceDeps.tournaments,
+      seatsRepo: serviceDeps.seats,
+      tablesRepo: serviceDeps.tables,
       scheduler,
       rooms,
-      new RebuyService(),
-      new PkoService(),
-      { get: jest.fn().mockResolvedValue(true) } as any,
-    );
+    });
     await service.scheduleTournament('t1', {
       registration: { open: new Date(now + 1000), close: new Date(now + 2000) },
       structure,

--- a/backend/test/tournament/structure-payouts.spec.ts
+++ b/backend/test/tournament/structure-payouts.spec.ts
@@ -1,19 +1,8 @@
-import { TournamentService } from '../../src/tournament/tournament.service';
-import { RebuyService } from '../../src/tournament/rebuy.service';
-import { PkoService } from '../../src/tournament/pko.service';
+import { createTournamentServiceInstance } from './helpers';
 import { icmRaw } from '@shared/utils/icm';
 
 describe('tournament structure payouts', () => {
-  const service = new TournamentService(
-    {} as any,
-    {} as any,
-    {} as any,
-    {} as any,
-    {} as any,
-    new RebuyService(),
-    new PkoService(),
-    { get: jest.fn().mockResolvedValue(true) } as any,
-  );
+  const service = createTournamentServiceInstance();
 
   it('computes freezeout payouts via ICM with <1 chip error', () => {
     const stacks = [5000, 3000, 2000];

--- a/backend/test/tournament/table-balancer.integration.spec.ts
+++ b/backend/test/tournament/table-balancer.integration.spec.ts
@@ -1,12 +1,15 @@
 import { TableBalancerService } from '../../src/tournament/table-balancer.service';
-import { TournamentService } from '../../src/tournament/tournament.service';
 import { Repository } from 'typeorm';
 import { Table } from '../../src/database/entities/table.entity';
 import { Seat } from '../../src/database/entities/seat.entity';
 import { Tournament, TournamentState } from '../../src/database/entities/tournament.entity';
 import { createTablesRepository } from './test-utils';
 import { createInMemoryRedis } from '../utils/mock-redis';
-import { createSeatRepo, createTournamentRepo } from './helpers';
+import {
+  createSeatRepo,
+  createTournamentRepo,
+  createTournamentServiceInstance,
+} from './helpers';
 
 describe('TableBalancerService integration', () => {
   it('balances 120 entrants across 10 tables', async () => {
@@ -46,13 +49,13 @@ describe('TableBalancerService integration', () => {
     ]);
     const scheduler: any = {};
     const rooms: any = { get: jest.fn() };
-    const service = new TournamentService(
+    const service = createTournamentServiceInstance({
       tournamentsRepo,
       seatsRepo,
       tablesRepo,
       scheduler,
       rooms,
-    );
+    });
     const { redis } = createInMemoryRedis();
     const balancer = new TableBalancerService(tablesRepo, service, redis);
 
@@ -109,13 +112,13 @@ describe('TableBalancerService integration', () => {
     ]);
     const scheduler: any = {};
     const rooms: any = { get: jest.fn() };
-    const service = new TournamentService(
+    const service = createTournamentServiceInstance({
       tournamentsRepo,
       seatsRepo,
       tablesRepo,
       scheduler,
       rooms,
-    );
+    });
     const { redis } = createInMemoryRedis();
     const balancer = new TableBalancerService(tablesRepo, service, redis);
 
@@ -186,13 +189,13 @@ describe('TableBalancerService integration', () => {
     ]);
     const scheduler: any = {};
     const rooms: any = { get: jest.fn() };
-    const service = new TournamentService(
+    const service = createTournamentServiceInstance({
       tournamentsRepo,
       seatsRepo,
       tablesRepo,
       scheduler,
       rooms,
-    );
+    });
     const { redis } = createInMemoryRedis();
     const balancer = new TableBalancerService(tablesRepo, service, redis);
 
@@ -215,13 +218,13 @@ describe('TableBalancerService integration', () => {
     });
 
     // simulate service restart
-    const service2 = new TournamentService(
+    const service2 = createTournamentServiceInstance({
       tournamentsRepo,
       seatsRepo,
       tablesRepo,
       scheduler,
       rooms,
-    );
+    });
     const balancer2 = new TableBalancerService(tablesRepo, service2, redis);
 
     await balancer2.rebalanceIfNeeded('t1', 12, 5);

--- a/backend/test/tournament/tournament-details.service.spec.ts
+++ b/backend/test/tournament/tournament-details.service.spec.ts
@@ -1,6 +1,6 @@
-import { TournamentService } from '../../src/tournament/tournament.service';
 import { TournamentState } from '../../src/database/entities/tournament.entity';
 import { TournamentDetailType } from '../../src/tournament/tournament-detail.entity';
+import { createTournamentServiceInstance } from './helpers';
 
 describe('TournamentService.get tournament details', () => {
   const baseTournament = {
@@ -24,22 +24,13 @@ describe('TournamentService.get tournament details', () => {
     const detailsRepository = {
       find: jest.fn().mockResolvedValue(detailRows),
     };
-    const service = new TournamentService(
-      { findOne: jest.fn() } as any,
-      seats as any,
-      {} as any,
-      {} as any,
-      {} as any,
-      {} as any,
-      {} as any,
-      { get: jest.fn() } as any,
-      {} as any,
-      {} as any,
-      {} as any,
-      {} as any,
-      {} as any,
-      detailsRepository as any,
-    );
+    const service = createTournamentServiceInstance({
+      tournamentsRepo: { findOne: jest.fn() } as any,
+      seatsRepo: seats as any,
+      tablesRepo: {} as any,
+      detailsOrWallet: detailsRepository as any,
+      flags: { get: jest.fn() } as any,
+    });
 
     jest
       .spyOn(service as any, 'getEntity')

--- a/backend/test/tournament/tournament.service.spec.ts
+++ b/backend/test/tournament/tournament.service.spec.ts
@@ -1,4 +1,4 @@
-import { TournamentService } from '../../src/tournament/tournament.service';
+import type { TournamentService } from '../../src/tournament/tournament.service';
 import {
   Tournament,
   TournamentState,
@@ -8,8 +8,7 @@ import { Table } from '../../src/database/entities/table.entity';
 import { Repository } from 'typeorm';
 import * as fc from 'fast-check';
 import { icmRaw } from '@shared/utils/icm';
-import { RebuyService } from '../../src/tournament/rebuy.service';
-import { PkoService } from '../../src/tournament/pko.service';
+import { createTournamentServiceInstance } from './helpers';
 
 describe('TournamentService algorithms', () => {
   let service: TournamentService;
@@ -79,24 +78,20 @@ describe('TournamentService algorithms', () => {
         balance += amount;
       }),
     };
-    service = new TournamentService(
-      tournamentsRepo as Repository<Tournament>,
-      seatsRepo as Repository<Seat>,
-      tablesRepo as Repository<Table>,
+    service = createTournamentServiceInstance({
+      tournamentsRepo: tournamentsRepo as Repository<Tournament>,
+      seatsRepo: seatsRepo as Repository<Seat>,
+      tablesRepo: tablesRepo as Repository<Table>,
       scheduler,
       rooms,
-      new RebuyService(),
-      new PkoService(),
       flags,
       events,
       producer,
-      botProfilesRepo,
-      filterOptionsRepo,
-      formatRepo,
-      undefined,
-      undefined,
+      botProfiles: botProfilesRepo,
+      filterOptions: filterOptionsRepo,
+      formatRepository: formatRepo,
       wallet,
-    );
+    });
   });
 
   describe('seat assignment flow', () => {
@@ -271,24 +266,20 @@ describe('TournamentService algorithms', () => {
       };
       const apply = jest.fn(async () => ({}));
       rooms.get.mockReturnValue({ apply });
-      service = new TournamentService(
-        tournamentsRepo as Repository<Tournament>,
-        seatsRepo as Repository<Seat>,
-        tablesRepo as Repository<Table>,
+      service = createTournamentServiceInstance({
+        tournamentsRepo: tournamentsRepo as Repository<Tournament>,
+        seatsRepo: seatsRepo as Repository<Seat>,
+        tablesRepo: tablesRepo as Repository<Table>,
         scheduler,
         rooms,
-        new RebuyService(),
-        new PkoService(),
         flags,
         events,
         producer,
-        botProfilesRepo,
-        filterOptionsRepo,
-        formatRepo,
-        undefined,
-        undefined,
+        botProfiles: botProfilesRepo,
+        filterOptions: filterOptionsRepo,
+        formatRepository: formatRepo,
         wallet,
-      );
+      });
 
       await service.autoFoldOnTimeout('s1');
 


### PR DESCRIPTION
## Summary
- update tournament unit and integration specs to import and use `createTournamentServiceInstance`
- pass explicit overrides for specs that configure repository or service mocks so helper wiring remains consistent

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d8d82fbdf08323992f5d42721ffc34