### PR TITLE
test: align tournament fixtures with helper defaults

### DIFF
--- a/backend/test/performance/tournament-10k.ts
+++ b/backend/test/performance/tournament-10k.ts
@@ -8,7 +8,7 @@ import { PkoService } from '../../src/tournament/pko.service';
 import { icmRaw } from '@shared/utils/icm';
 import { Seat } from '../../src/database/entities/seat.entity';
 import { Table } from '../../src/database/entities/table.entity';
-import { Tournament } from '../../src/database/entities/tournament.entity';
+import { createTestTable, createTestTournament } from '../tournament/helpers';
 
 interface StructureLevel {
   level: number;
@@ -27,11 +27,11 @@ async function runSimulation(players: number, assertIcm = false): Promise<number
   const start = Date.now();
 
   const tableCount = Math.max(1, Math.ceil(players / 100));
-  const tables: Table[] = Array.from({ length: tableCount }, (_, i) => ({
-    id: `tbl${i}`,
-    seats: [] as Seat[],
-    tournament: { id: 't1' } as Tournament,
-  })) as Table[];
+  const tournament = createTestTournament({ id: 't1' });
+  const tables: Table[] = Array.from({ length: tableCount }, (_, i) =>
+    createTestTable(`tbl${i}`, tournament),
+  );
+  tournament.tables = tables;
 
   let seatId = 0;
   for (let i = 0; i < players; i++) {

--- a/backend/test/tournament.join.rollback.spec.ts
+++ b/backend/test/tournament.join.rollback.spec.ts
@@ -1,11 +1,13 @@
 import { TournamentService } from '../src/tournament/tournament.service';
-import { Tournament, TournamentState } from '../src/database/entities/tournament.entity';
+import type { Tournament } from '../src/database/entities/tournament.entity';
+import { TournamentState } from '../src/database/entities/tournament.entity';
 import { Seat } from '../src/database/entities/seat.entity';
 import { Table } from '../src/database/entities/table.entity';
 import { Repository } from 'typeorm';
 import type { WalletService } from '../src/wallet/wallet.service';
 import {
   createTestTable,
+  createTestTournament,
   createTournamentRepo,
   createTournamentServiceInstance,
 } from './tournament/helpers';
@@ -18,18 +20,15 @@ describe('TournamentService.join rollback', () => {
   let wallet: { reserve: jest.Mock; rollback: jest.Mock };
 
   beforeEach(() => {
-    const tournament = {
+    const tournament = createTestTournament({
       id: 't1',
       title: 'Daily Free Roll',
       buyIn: 100,
       prizePool: 1000,
-      currency: 'USD',
       maxPlayers: 100,
       state: TournamentState.REG_OPEN,
       gameType: 'texas',
-      tables: [],
-      details: [],
-    } as Tournament;
+    });
 
     const table = createTestTable('tbl1', tournament);
     tournament.tables = [table];

--- a/backend/test/tournament.sim.spec.ts
+++ b/backend/test/tournament.sim.spec.ts
@@ -1,31 +1,29 @@
 import { TableBalancerService } from '../src/tournament/table-balancer.service';
 import { Table } from '../src/database/entities/table.entity';
 import { Seat } from '../src/database/entities/seat.entity';
-import {
-  Tournament,
-  TournamentState,
-} from '../src/database/entities/tournament.entity';
+import type { Tournament } from '../src/database/entities/tournament.entity';
+import { TournamentState } from '../src/database/entities/tournament.entity';
 import { RebuyService } from '../src/tournament/rebuy.service';
 import { PkoService } from '../src/tournament/pko.service';
 import { icmRaw } from '@shared/utils/icm';
 import {
   createSeatRepo,
   createTestTable,
+  createTestTournament,
   createTournamentRepo,
   createTournamentServiceInstance,
 } from './tournament/helpers';
 
 describe('tournament simulation', () => {
   it('simulates 10k entrants with late registration and bubble payouts', async () => {
-    const tournament = {
+    const tournament = createTestTournament({
       id: 't1',
       title: 'Mega',
       buyIn: 100,
       prizePool: 0,
       maxPlayers: 10000,
       state: TournamentState.RUNNING,
-      tables: [] as Table[],
-    } as Tournament;
+    });
     const tables: Table[] = Array.from({ length: 100 }, (_, i) =>
       createTestTable(`tbl${i}`, tournament),
     );
@@ -141,16 +139,14 @@ describe('tournament simulation', () => {
       find: jest.fn(async () => []),
     } as any;
     const seatsRepo = { manager: undefined } as any;
-    const tournament = {
+    const tournament = createTestTournament({
       id: 't-empty',
       title: 'Empty',
       state: TournamentState.REG_OPEN,
       buyIn: 100,
-      currency: 'USD',
       prizePool: 0,
       maxPlayers: 9,
-      tables: [] as Table[],
-    } as Tournament;
+    });
     const tournamentsRepo = createTournamentRepo([tournament]);
     const scheduler: any = {};
     const rooms: any = { get: jest.fn() };

--- a/backend/test/tournament.spec.ts
+++ b/backend/test/tournament.spec.ts
@@ -1,6 +1,7 @@
 import { TournamentScheduler } from '../src/tournament/scheduler.service';
 import { TableBalancerService } from '../src/tournament/table-balancer.service';
-import { Tournament, TournamentState } from '../src/database/entities/tournament.entity';
+import type { Tournament } from '../src/database/entities/tournament.entity';
+import { TournamentState } from '../src/database/entities/tournament.entity';
 import { Table } from '../src/database/entities/table.entity';
 import { Seat } from '../src/database/entities/seat.entity';
 import { RebuyService } from '../src/tournament/rebuy.service';
@@ -9,20 +10,20 @@ import type { EventPublisher } from '../src/events/events.service';
 import {
   createSeatRepo,
   createTestTable,
+  createTestTournament,
   createTournamentRepo,
   createTournamentServiceInstance,
 } from './tournament/helpers';
 
 function createTournamentContext(): { tournament: Tournament; tables: Table[] } {
-  const tournament = {
+  const tournament = createTestTournament({
     id: 't1',
     title: 'Test',
     buyIn: 0,
     prizePool: 0,
     maxPlayers: 100,
     state: TournamentState.RUNNING,
-    tables: [] as Table[],
-  } as Tournament;
+  });
   const tables = [
     createTestTable('tbl1', tournament),
     createTestTable('tbl2', tournament),
@@ -168,15 +169,14 @@ describe('Tournament scheduling and balancing', () => {
   });
 
   it('emits bubble event when players reach payout threshold', async () => {
-    const tournament = {
+    const tournament = createTestTournament({
       id: 't1',
       title: 'Bubble Test',
       buyIn: 0,
       prizePool: 0,
       maxPlayers: 100,
       state: TournamentState.RUNNING,
-      tables: [] as Table[],
-    } as Tournament;
+    });
     const tables = [createTestTable('tbl1', tournament)];
     tournament.tables = tables;
     for (let i = 0; i < 5; i++) {

--- a/backend/test/tournament/avoid-within.spec.ts
+++ b/backend/test/tournament/avoid-within.spec.ts
@@ -2,27 +2,28 @@ import { TableBalancerService } from '../../src/tournament/table-balancer.servic
 import { TournamentService } from '../../src/tournament/tournament.service';
 import { Table } from '../../src/database/entities/table.entity';
 import { Seat } from '../../src/database/entities/seat.entity';
-import { Tournament, TournamentState } from '../../src/database/entities/tournament.entity';
+import type { Tournament } from '../../src/database/entities/tournament.entity';
+import { TournamentState } from '../../src/database/entities/tournament.entity';
 import { ConfigService } from '@nestjs/config';
 import type Redis from 'ioredis';
 import { createInMemoryRedis } from '../utils/mock-redis';
 import {
   createSeatRepo,
   createTestTable,
+  createTestTournament,
   createTournamentRepo,
   createTournamentServiceInstance,
 } from './helpers';
 
 function createTournamentContext() {
-  const tournament = {
+  const tournament = createTestTournament({
     id: 't1',
     title: 'Test',
     buyIn: 0,
     prizePool: 0,
     maxPlayers: 1000,
     state: TournamentState.RUNNING,
-    tables: [] as Table[],
-  } as Tournament;
+  });
   const tables = [
     createTestTable('tbl1', tournament),
     createTestTable('tbl2', tournament),

--- a/backend/test/tournament/helpers.ts
+++ b/backend/test/tournament/helpers.ts
@@ -1,6 +1,6 @@
 import type { Repository, FindOneOptions, FindOptionsWhere } from 'typeorm';
 import type Redis from 'ioredis';
-import { Tournament } from '../../src/database/entities/tournament.entity';
+import { Tournament, TournamentState } from '../../src/database/entities/tournament.entity';
 import { Table } from '../../src/database/entities/table.entity';
 import { Seat } from '../../src/database/entities/seat.entity';
 import { TournamentService } from '../../src/tournament/tournament.service';
@@ -73,6 +73,27 @@ export function createSeatRepo(tables: Table[]): Repository<Seat> {
       return Array.isArray(seat) ? arr : arr[0];
     }),
   } as unknown as Repository<Seat>;
+}
+
+export function createTestTournament(
+  overrides: Partial<Tournament> = {},
+): Tournament {
+  const tournament: Tournament = {
+    id: 'tournament',
+    title: 'Test Tournament',
+    gameType: 'texas',
+    buyIn: 0,
+    currency: 'USD',
+    prizePool: 0,
+    maxPlayers: 0,
+    state: TournamentState.REG_OPEN,
+    tables: [],
+    details: [],
+    registrationOpen: undefined,
+    registrationClose: undefined,
+  } as Tournament;
+
+  return Object.assign(tournament, overrides);
 }
 
 export function createTestTable(id: string, tournament: Tournament): Table {

--- a/backend/test/tournament/last-moved-hand.spec.ts
+++ b/backend/test/tournament/last-moved-hand.spec.ts
@@ -2,19 +2,23 @@ import { TableBalancerService } from '../../src/tournament/table-balancer.servic
 import { TournamentService } from '../../src/tournament/tournament.service';
 import { Table } from '../../src/database/entities/table.entity';
 import { Seat } from '../../src/database/entities/seat.entity';
-import {
-  Tournament,
-  TournamentState,
-} from '../../src/database/entities/tournament.entity';
+import { TournamentState } from '../../src/database/entities/tournament.entity';
 import { Repository } from 'typeorm';
-import { createSeatRepo, createTournamentRepo } from './helpers';
+import {
+  createSeatRepo,
+  createTestTable,
+  createTestTournament,
+  createTournamentRepo,
+} from './helpers';
 
 describe('TableBalancerService lastMovedHand persistence', () => {
   it('skips moves for players who recently moved even after restart', async () => {
+    const tournament = createTestTournament({ id: 't1', state: TournamentState.RUNNING });
     const tables: Table[] = [
-      { id: 'tbl1', seats: [], tournament: { id: 't1' } as Tournament } as Table,
-      { id: 'tbl2', seats: [], tournament: { id: 't1' } as Tournament } as Table,
+      createTestTable('tbl1', tournament),
+      createTestTable('tbl2', tournament),
     ];
+    tournament.tables = tables;
     const players1 = ['p1', 'p2', 'p3', 'p4'];
     const players2 = ['p5', 'p6'];
     let seatId = 0;
@@ -40,17 +44,7 @@ describe('TableBalancerService lastMovedHand persistence', () => {
     });
     const seatsRepo = createSeatRepo(tables);
     const tablesRepo = { find: jest.fn(async () => tables) } as any;
-    const tournamentsRepo = createTournamentRepo([
-      {
-        id: 't1',
-        title: 'Test',
-        buyIn: 0,
-        prizePool: 0,
-        maxPlayers: 1000,
-        state: TournamentState.RUNNING,
-        tables,
-      } as Tournament,
-    ]);
+    const tournamentsRepo = createTournamentRepo([tournament]);
     const scheduler: any = {};
     const rooms: any = { get: jest.fn() };
     const service = new TournamentService(

--- a/backend/test/tournament/manage-seat.spec.ts
+++ b/backend/test/tournament/manage-seat.spec.ts
@@ -1,13 +1,12 @@
 import { TournamentService } from '../../src/tournament/tournament.service';
-import {
-  Tournament,
-  TournamentState,
-} from '../../src/database/entities/tournament.entity';
+import type { Tournament } from '../../src/database/entities/tournament.entity';
+import { TournamentState } from '../../src/database/entities/tournament.entity';
 import { Seat } from '../../src/database/entities/seat.entity';
 import { Table } from '../../src/database/entities/table.entity';
 import { Repository } from 'typeorm';
 import { RebuyService } from '../../src/tournament/rebuy.service';
 import { PkoService } from '../../src/tournament/pko.service';
+import { createTestTable, createTestTournament } from './helpers';
 
 interface SetupTournamentServiceOptions {
   useTransactionManager?: boolean;
@@ -42,17 +41,16 @@ function setupTournamentService({
   useTransactionManager = false,
   failSave = false,
 }: SetupTournamentServiceOptions = {}): SetupTournamentServiceResult {
-  const tournament: Tournament = {
+  const tournament = createTestTournament({
     id: 't1',
     title: 'Daily',
     buyIn: 100,
-    gameType: 'texas',
     prizePool: 1000,
     maxPlayers: 100,
     state: TournamentState.REG_OPEN,
-    tables: [],
-    currency: 'USD',
-  } as Tournament;
+  });
+  const table = createTestTable('tbl1', tournament);
+  tournament.tables = [table];
 
   const tournamentsRepo = {
     findOne: jest.fn(async ({ where: { id } }: any) =>
@@ -61,9 +59,7 @@ function setupTournamentService({
   };
 
   const tablesRepo = {
-    find: jest.fn(async () => [
-      { id: 'tbl1', seats: [], tournament: { id: 't1' } as Tournament } as Table,
-    ]),
+    find: jest.fn(async () => [table]),
   };
 
   const seats = new Set<Seat>();

--- a/backend/test/tournament/mega-sim.spec.ts
+++ b/backend/test/tournament/mega-sim.spec.ts
@@ -7,7 +7,7 @@ import { PkoService } from '../../src/tournament/pko.service';
 import { calculateIcmPayouts } from '@shared/utils/icm';
 import { Seat } from '../../src/database/entities/seat.entity';
 import { Table } from '../../src/database/entities/table.entity';
-import { Tournament } from '../../src/database/entities/tournament.entity';
+import { createTestTable, createTestTournament } from './helpers';
 
 async function runSimulation(players: number, checkIcm = false): Promise<number> {
   const start = Date.now();
@@ -20,11 +20,11 @@ async function runSimulation(players: number, checkIcm = false): Promise<number>
   };
 
   const tableCount = Math.max(1, Math.ceil(players / 100));
-  const tables: Table[] = Array.from({ length: tableCount }, (_, i) => ({
-    id: `tbl${i}`,
-    seats: [] as Seat[],
-    tournament: { id: 't1' } as Tournament,
-  })) as Table[];
+  const tournament = createTestTournament({ id: 't1' });
+  const tables: Table[] = Array.from({ length: tableCount }, (_, i) =>
+    createTestTable(`tbl${i}`, tournament),
+  );
+  tournament.tables = tables;
 
   let seatId = 0;
   for (let i = 0; i < players; i++) {

--- a/backend/test/tournament/scheduler.spec.ts
+++ b/backend/test/tournament/scheduler.spec.ts
@@ -3,10 +3,10 @@ import { TableBalancerService } from '../../src/tournament/table-balancer.servic
 import { TournamentService } from '../../src/tournament/tournament.service';
 import { Table } from '../../src/database/entities/table.entity';
 import { Seat } from '../../src/database/entities/seat.entity';
-import { Tournament } from '../../src/database/entities/tournament.entity';
 import { RebuyService } from '../../src/tournament/rebuy.service';
 import { PkoService } from '../../src/tournament/pko.service';
 import { icmRaw } from '@shared/utils/icm';
+import { createTestTable, createTestTournament } from './helpers';
 
 describe('TournamentScheduler', () => {
   it('schedules level up jobs', async () => {
@@ -103,11 +103,11 @@ describe('TournamentScheduler', () => {
       level: i + 1,
       durationMinutes: 1,
     }));
-    const tables: Table[] = Array.from({ length: 100 }, (_, i) => ({
-      id: `tbl${i}`,
-      seats: [],
-      tournament: { id: 't1' } as Tournament,
-    })) as Table[];
+    const tournament = createTestTournament({ id: 't1' });
+    const tables: Table[] = Array.from({ length: 100 }, (_, i) =>
+      createTestTable(`tbl${i}`, tournament),
+    );
+    tournament.tables = tables;
 
     const serviceDeps = {
       tournaments: { find: jest.fn(), findOne: jest.fn(), save: jest.fn() } as any,

--- a/backend/test/tournament/test-utils.ts
+++ b/backend/test/tournament/test-utils.ts
@@ -1,6 +1,8 @@
 import type { Repository } from 'typeorm';
 import { Table } from '../../src/database/entities/table.entity';
+import { Seat } from '../../src/database/entities/seat.entity';
 import { createInMemoryRedis } from '../utils/mock-redis';
+import { createTestTable, createTestTournament } from './helpers';
 
 export type TournamentService = {
   balanceTournament(
@@ -14,12 +16,71 @@ export type TournamentService = {
 export function createTablesRepository(
   data: string[][] | Table[],
 ): Partial<Repository<Table>> {
-  const tables: Table[] = Array.isArray(data) && typeof data[0]?.[0] === 'string'
-    ? (data as string[][]).map((pids, i) => ({
-        id: `table${i}`,
-        seats: pids.map((id) => ({ user: { id } })),
-      }))
-    : (data as Table[]);
+  const ensureTableDefaults = (table: Table, index: number): Table => {
+    const tournament =
+      table.tournament ?? createTestTournament({ id: `tournament${index}` });
+    if (!tournament.tables) {
+      tournament.tables = [];
+    }
+    if (!tournament.details) {
+      tournament.details = [];
+    }
+
+    const base = createTestTable(table.id ?? `table${index}`, tournament);
+    const providedSeats = table.seats;
+    const providedPlayers = table.players;
+
+    Object.assign(table, base, table);
+    table.tournament = tournament;
+    if (!tournament.tables.includes(table)) {
+      tournament.tables.push(table);
+    }
+
+    const seats = providedSeats ?? [];
+    if (!providedSeats) {
+      table.seats = seats;
+    }
+    seats.forEach((seat, seatIndex) => {
+      seat.id = seat.id ?? `seat${table.id}-${seatIndex}`;
+      seat.table = table;
+      seat.position = seat.position ?? seatIndex;
+      seat.user = seat.user ?? ({ id: `player${seatIndex}` } as any);
+      seat.lastMovedHand = seat.lastMovedHand ?? 0;
+    });
+    table.seats = seats;
+
+    if (providedPlayers) {
+      table.players = providedPlayers;
+    } else {
+      table.players = table.seats.map((seat) => seat.user);
+    }
+    table.playersCurrent = table.playersCurrent ?? table.seats.length;
+
+    return table;
+  };
+
+  const tables: Table[] =
+    Array.isArray(data) && typeof data[0]?.[0] === 'string'
+      ? (() => {
+          const tournament = createTestTournament({ id: 'tournament' });
+          return (data as string[][]).map((pids, i) => {
+            const table = createTestTable(`table${i}`, tournament);
+            table.seats = pids.map((id, seatIndex) => ({
+              id: `seat${i}-${seatIndex}`,
+              table,
+              user: { id } as any,
+              position: seatIndex,
+              lastMovedHand: 0,
+            })) as Seat[];
+            table.players = table.seats.map((seat) => seat.user);
+            table.playersCurrent = table.seats.length;
+            if (!tournament.tables.includes(table)) {
+              tournament.tables.push(table);
+            }
+            return table;
+          });
+        })()
+      : (data as Table[]).map(ensureTableDefaults);
   return {
     find: jest.fn().mockResolvedValue(tables),
   };

--- a/backend/test/tournament/tournament.service.spec.ts
+++ b/backend/test/tournament/tournament.service.spec.ts
@@ -1,8 +1,6 @@
 import { TournamentService } from '../../src/tournament/tournament.service';
-import {
-  Tournament,
-  TournamentState,
-} from '../../src/database/entities/tournament.entity';
+import type { Tournament } from '../../src/database/entities/tournament.entity';
+import { TournamentState } from '../../src/database/entities/tournament.entity';
 import { Seat } from '../../src/database/entities/seat.entity';
 import { Table } from '../../src/database/entities/table.entity';
 import { Repository } from 'typeorm';
@@ -10,6 +8,7 @@ import * as fc from 'fast-check';
 import { icmRaw } from '@shared/utils/icm';
 import { RebuyService } from '../../src/tournament/rebuy.service';
 import { PkoService } from '../../src/tournament/pko.service';
+import { createTestTable, createTestTournament } from './helpers';
 
 describe('TournamentService algorithms', () => {
   let service: TournamentService;
@@ -50,16 +49,14 @@ describe('TournamentService algorithms', () => {
       scheduleLevelUps: jest.fn(),
     };
     tournamentsRepo = createRepo<Tournament>([
-      {
+      createTestTournament({
         id: 't1',
         title: 'Daily Free Roll',
         buyIn: 100,
-        gameType: 'texas',
         prizePool: 1000,
         maxPlayers: 100,
         state: TournamentState.REG_OPEN,
-        tables: [],
-      } as Tournament,
+      }),
     ]);
     seatsRepo = createRepo<Seat>();
     tablesRepo = { find: jest.fn().mockResolvedValue([]) };
@@ -101,9 +98,10 @@ describe('TournamentService algorithms', () => {
 
   describe('seat assignment flow', () => {
     it('joins and withdraws a player', async () => {
-      tablesRepo.find.mockResolvedValue([
-        { id: 'tbl1', seats: [], tournament: { id: 't1' } as Tournament } as Table,
-      ]);
+      const tournament = createTestTournament({ id: 't1' });
+      const table = createTestTable('tbl1', tournament);
+      tournament.tables = [table];
+      tablesRepo.find.mockResolvedValue([table]);
       const seat = await service.join('t1', 'u1');
       expect(wallet.reserve).toHaveBeenCalledWith('u1', 100, 't1', 'USD');
       expect(events.emit).toHaveBeenCalledWith('wallet.reserve', {


### PR DESCRIPTION
## Summary
- add a shared `createTestTournament` helper and ensure the table repository helper returns fully populated entities
- refactor tournament-related specs to build tables via helpers and populate the new currency/details fields

## Testing
- npm run test -- --runTestsByPath backend/test/tournament.spec.ts *(fails: missing ts-node/register in scripts workspace)*

------
https://chatgpt.com/codex/tasks/task_e_68d8d83894ac8323a29ce8cf46b5d3c6