### PR TITLE
fix(backend): wrap typeorm imports with crypto shim

### DIFF
--- a/backend/src/analytics/analytics.module.ts
+++ b/backend/src/analytics/analytics.module.ts
@@ -11,7 +11,7 @@ import { AnalyticsController } from './analytics.controller';
 import { WalletModule } from '../wallet/wallet.module';
 import { AuthModule } from '../auth/auth.module';
 import { StorageModule } from '../storage/storage.module';
-import { TypeOrmModule } from '@nestjs/typeorm';
+import { TypeOrmModule } from '../shims/typeorm';
 import { CollusionAudit } from './collusion-audit.entity';
 import { AuditLogTypeClass } from './audit-log-type-class.entity';
 import { AuditLogTypeClassDefault } from './audit-log-type-class-default.entity';

--- a/backend/src/analytics/analytics.service.ts
+++ b/backend/src/analytics/analytics.service.ts
@@ -7,7 +7,7 @@ import {
   ServiceUnavailableException,
   forwardRef,
 } from '@nestjs/common';
-import { InjectRepository } from '@nestjs/typeorm';
+import { InjectRepository } from '../shims/typeorm';
 import { ConfigService } from '@nestjs/config';
 import { createClient, ClickHouseClient } from '@clickhouse/client';
 import { randomUUID } from 'crypto';

--- a/backend/src/analytics/collusion.service.ts
+++ b/backend/src/analytics/collusion.service.ts
@@ -8,7 +8,7 @@ import {
   clusterBySharedValues,
 } from '@shared/analytics/collusion';
 import { AnalyticsService } from './analytics.service';
-import { InjectRepository } from '@nestjs/typeorm';
+import { InjectRepository } from '../shims/typeorm';
 import { Repository } from 'typeorm';
 import {
   CollusionAudit,

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -1,7 +1,7 @@
 import './shims/crypto';
 
 import { Logger, Module } from '@nestjs/common';
-import { TypeOrmModule } from '@nestjs/typeorm';
+import { TypeOrmModule } from './shims/typeorm';
 import { DataSource, type DataSourceOptions } from 'typeorm';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { LoggerModule } from 'nestjs-pino';

--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -8,7 +8,7 @@ import {
   forwardRef,
 } from '@nestjs/common';
 import { ConfigModule, ConfigService } from '@nestjs/config';
-import { TypeOrmModule } from '@nestjs/typeorm';
+import { TypeOrmModule } from '../shims/typeorm';
 import { KycService } from '../common/kyc.service';
 import { providerFactory } from './providers';
 import { Account } from '../wallet/account.entity';

--- a/backend/src/common/kyc.service.ts
+++ b/backend/src/common/kyc.service.ts
@@ -8,7 +8,7 @@ import {
 import { ConfigService } from '@nestjs/config';
 import { CACHE_MANAGER } from '@nestjs/cache-manager';
 import type { Cache } from 'cache-manager';
-import { InjectRepository } from '@nestjs/typeorm';
+import { InjectRepository } from '../shims/typeorm';
 import type { Queue } from 'bullmq';
 import { Repository } from 'typeorm';
 import { KycVerification } from '../database/entities/kycVerification.entity';

--- a/backend/src/ctas/ctas.module.ts
+++ b/backend/src/ctas/ctas.module.ts
@@ -1,5 +1,5 @@
 import { Module } from '@nestjs/common';
-import { TypeOrmModule } from '@nestjs/typeorm';
+import { TypeOrmModule } from '../shims/typeorm';
 import { CtasController } from '../routes/ctas.controller';
 import { CTA } from '../database/entities/cta.entity';
 import { CTARepository } from './cta.repository';

--- a/backend/src/game/chat.service.ts
+++ b/backend/src/game/chat.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { InjectRepository } from '@nestjs/typeorm';
+import { InjectRepository } from '../shims/typeorm';
 import { Repository } from 'typeorm';
 import { ChatMessage } from '../database/entities/chatMessage.entity';
 import { Table } from '../database/entities/table.entity';

--- a/backend/src/game/game.gateway.ts
+++ b/backend/src/game/game.gateway.ts
@@ -19,7 +19,7 @@ import { CollusionService } from '../analytics/collusion.service';
 import { ClockService } from './clock.service';
 import { FeatureFlagsService } from '../feature-flags/feature-flags.service';
 
-import { InjectRepository } from '@nestjs/typeorm';
+import { InjectRepository } from '../shims/typeorm';
 import { Repository } from 'typeorm';
 import { Hand } from '../database/entities/hand.entity';
 import { GameState as GameStateEntity } from '../database/entities/game-state.entity';

--- a/backend/src/game/game.module.ts
+++ b/backend/src/game/game.module.ts
@@ -4,7 +4,7 @@ import { SpectatorGateway } from './spectator.gateway';
 import { RoomManager } from './room.service';
 import { AnalyticsModule } from '../analytics/analytics.module';
 import { ClockService } from './clock.service';
-import { TypeOrmModule } from '@nestjs/typeorm';
+import { TypeOrmModule } from '../shims/typeorm';
 import { Hand } from '../database/entities/hand.entity';
 import { Table } from '../database/entities/table.entity';
 import { ChatMessage } from '../database/entities/chatMessage.entity';

--- a/backend/src/game/hand.controller.ts
+++ b/backend/src/game/hand.controller.ts
@@ -11,7 +11,7 @@ import {
   Query,
 } from '@nestjs/common';
 import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
-import { InjectRepository } from '@nestjs/typeorm';
+import { InjectRepository } from '../shims/typeorm';
 import { createReadStream } from 'fs';
 import { readFile, readdir, stat } from 'fs/promises';
 import { Readable } from 'stream';

--- a/backend/src/game/tables.service.ts
+++ b/backend/src/game/tables.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
-import { InjectRepository } from '@nestjs/typeorm';
+import { InjectRepository } from '../shims/typeorm';
 import { In, Repository } from 'typeorm';
 import { Table as TableEntity } from '../database/entities/table.entity';
 import { User } from '../database/entities/user.entity';

--- a/backend/src/history/history.module.ts
+++ b/backend/src/history/history.module.ts
@@ -1,5 +1,5 @@
 import { Module } from '@nestjs/common';
-import { TypeOrmModule } from '@nestjs/typeorm';
+import { TypeOrmModule } from '../shims/typeorm';
 import { DataSource } from 'typeorm';
 import { HistoryController } from './history.controller';
 import { HistoryService } from './history.service';

--- a/backend/src/leaderboard/leaderboard-config.service.ts
+++ b/backend/src/leaderboard/leaderboard-config.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, OnModuleInit } from '@nestjs/common';
-import { InjectRepository } from '@nestjs/typeorm';
+import { InjectRepository } from '../shims/typeorm';
 import { Repository } from 'typeorm';
 import { LeaderboardConfigEntity } from '../database/entities/leaderboard-config.entity';
 import type {

--- a/backend/src/leaderboard/leaderboard.module.ts
+++ b/backend/src/leaderboard/leaderboard.module.ts
@@ -1,5 +1,5 @@
 import { Module, Injectable, OnModuleInit } from '@nestjs/common';
-import { TypeOrmModule } from '@nestjs/typeorm';
+import { TypeOrmModule } from '../shims/typeorm';
 import { RedisModule } from '../redis/redis.module';
 import { LeaderboardService } from './leaderboard.service';
 import { startLeaderboardRebuildWorker } from './rebuild.worker';

--- a/backend/src/leaderboard/leaderboard.service.ts
+++ b/backend/src/leaderboard/leaderboard.service.ts
@@ -1,7 +1,7 @@
 import { Inject, Injectable, OnModuleInit } from '@nestjs/common';
 import { CACHE_MANAGER } from '@nestjs/cache-manager';
 import type { Cache } from 'cache-manager';
-import { InjectRepository } from '@nestjs/typeorm';
+import { InjectRepository } from '../shims/typeorm';
 import { In, Repository, type DeepPartial } from 'typeorm';
 import { readFileSync } from 'fs';
 import { join } from 'path';

--- a/backend/src/messaging/messaging.module.ts
+++ b/backend/src/messaging/messaging.module.ts
@@ -2,7 +2,7 @@ import { Module, Logger } from '@nestjs/common';
 import { ClientsModule, Transport } from '@nestjs/microservices';
 import type { RmqOptions } from '@nestjs/microservices';
 import { ConfigService } from '@nestjs/config';
-import { TypeOrmModule } from '@nestjs/typeorm';
+import { TypeOrmModule } from '../shims/typeorm';
 import { TournamentsProducer } from './tournaments/tournaments.producer';
 import { TournamentsConsumer } from './tournaments/tournaments.consumer';
 import { AnalyticsModule } from '../analytics/analytics.module';

--- a/backend/src/nav/nav.module.ts
+++ b/backend/src/nav/nav.module.ts
@@ -1,5 +1,5 @@
 import { Module } from '@nestjs/common';
-import { TypeOrmModule } from '@nestjs/typeorm';
+import { TypeOrmModule } from '../shims/typeorm';
 import { NavController } from './nav.controller';
 import { NavService } from './nav.service';
 import { NavItemEntity } from '../database/entities/nav-item.entity';

--- a/backend/src/nav/nav.service.ts
+++ b/backend/src/nav/nav.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
-import { InjectRepository } from '@nestjs/typeorm';
+import { InjectRepository } from '../shims/typeorm';
 import { Repository } from 'typeorm';
 import type { NavItem, NavItemRequest } from '@shared/types';
 import { NavItemEntity } from '../database/entities/nav-item.entity';

--- a/backend/src/notifications/admin-messages.service.ts
+++ b/backend/src/notifications/admin-messages.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
-import { InjectRepository } from '@nestjs/typeorm';
+import { InjectRepository } from '../shims/typeorm';
 import { Repository } from 'typeorm';
 import { AdminMessageEntity } from './admin-message.entity';
 import type { AdminMessage } from '../schemas/messages';

--- a/backend/src/notifications/notifications.listener.ts
+++ b/backend/src/notifications/notifications.listener.ts
@@ -6,7 +6,7 @@ import {
   Logger,
   Inject,
 } from '@nestjs/common';
-import { InjectRepository } from '@nestjs/typeorm';
+import { InjectRepository } from '../shims/typeorm';
 import { Repository } from 'typeorm';
 import { Consumer } from 'kafkajs';
 import { ConfigService } from '@nestjs/config';

--- a/backend/src/notifications/notifications.module.ts
+++ b/backend/src/notifications/notifications.module.ts
@@ -1,5 +1,5 @@
 import { Module } from '@nestjs/common';
-import { TypeOrmModule } from '@nestjs/typeorm';
+import { TypeOrmModule } from '../shims/typeorm';
 import { Notification } from './notification.entity';
 import { NotificationsService } from './notifications.service';
 import { NotificationsController } from './notifications.controller';

--- a/backend/src/notifications/notifications.service.ts
+++ b/backend/src/notifications/notifications.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { InjectRepository } from '@nestjs/typeorm';
+import { InjectRepository } from '../shims/typeorm';
 import { Repository } from 'typeorm';
 import { Notification } from './notification.entity';
 import type { NotificationFilter, NotificationType } from '../schemas/notifications';

--- a/backend/src/promotions/promotions.service.ts
+++ b/backend/src/promotions/promotions.service.ts
@@ -1,5 +1,5 @@
 import { ConflictException, Injectable, NotFoundException } from '@nestjs/common';
-import { InjectRepository } from '@nestjs/typeorm';
+import { InjectRepository } from '../shims/typeorm';
 import { Repository } from 'typeorm';
 import type { MessageResponse, Promotion } from '@shared/types';
 import { API_CONTRACT_VERSION } from '@shared/constants';

--- a/backend/src/services/admin-tabs.service.ts
+++ b/backend/src/services/admin-tabs.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
-import { InjectRepository } from '@nestjs/typeorm';
+import { InjectRepository } from '../shims/typeorm';
 import { Repository } from 'typeorm';
 import {
   type AdminTabConfig,

--- a/backend/src/services/blocked-countries.service.ts
+++ b/backend/src/services/blocked-countries.service.ts
@@ -3,7 +3,7 @@ import {
   Injectable,
   NotFoundException,
 } from '@nestjs/common';
-import { InjectRepository } from '@nestjs/typeorm';
+import { InjectRepository } from '../shims/typeorm';
 import { Repository } from 'typeorm';
 import type { BlockedCountry } from '@shared/types';
 import { BlockedCountryEntity } from '../database/entities/blocked-country.entity';

--- a/backend/src/services/bonus.service.ts
+++ b/backend/src/services/bonus.service.ts
@@ -4,7 +4,7 @@ import {
   NotFoundException,
 } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import { InjectRepository } from '@nestjs/typeorm';
+import { InjectRepository } from '../shims/typeorm';
 import { Repository } from 'typeorm';
 import { BonusOptionEntity } from '../database/entities/bonus-option.entity';
 import {

--- a/backend/src/services/chip-denoms.service.ts
+++ b/backend/src/services/chip-denoms.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { InjectRepository } from '@nestjs/typeorm';
+import { InjectRepository } from '../shims/typeorm';
 import { Repository } from 'typeorm';
 import { ChipDenominationEntity } from '../database/entities/chip-denomination.entity';
 

--- a/backend/src/services/default-avatar.service.ts
+++ b/backend/src/services/default-avatar.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { InjectRepository } from '@nestjs/typeorm';
+import { InjectRepository } from '../shims/typeorm';
 import { Repository } from 'typeorm';
 import { DefaultAvatarEntity } from '../database/entities/default-avatar.entity';
 

--- a/backend/src/services/history-tabs.service.ts
+++ b/backend/src/services/history-tabs.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { InjectRepository } from '@nestjs/typeorm';
+import { InjectRepository } from '../shims/typeorm';
 import { Repository } from 'typeorm';
 import type { HistoryTabItem } from '@shared/types';
 import { HistoryTabEntity } from '../database/entities/history-tab.entity';

--- a/backend/src/services/languages.service.ts
+++ b/backend/src/services/languages.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { InjectRepository } from '@nestjs/typeorm';
+import { InjectRepository } from '../shims/typeorm';
 import { Repository } from 'typeorm';
 import type { Language } from '@shared/types';
 import { LanguageEntity } from '../database/entities/language.entity';

--- a/backend/src/services/nav-icons.service.ts
+++ b/backend/src/services/nav-icons.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
-import { InjectRepository } from '@nestjs/typeorm';
+import { InjectRepository } from '../shims/typeorm';
 import { Repository } from 'typeorm';
 import { NavIconsResponseSchema, type NavIcon } from '@shared/types';
 import { NavIconEntity } from '../database/entities/nav-icon.entity';

--- a/backend/src/services/performance-thresholds.service.ts
+++ b/backend/src/services/performance-thresholds.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { InjectRepository } from '@nestjs/typeorm';
+import { InjectRepository } from '../shims/typeorm';
 import { Repository } from 'typeorm';
 import {
   PerformanceThresholdEntity,

--- a/backend/src/services/settings.service.ts
+++ b/backend/src/services/settings.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { InjectRepository } from '@nestjs/typeorm';
+import { InjectRepository } from '../shims/typeorm';
 import { Repository } from 'typeorm';
 import { ChartPaletteEntity } from '../database/entities/chart-palette.entity';
 

--- a/backend/src/services/table-theme.service.ts
+++ b/backend/src/services/table-theme.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
-import { InjectRepository } from '@nestjs/typeorm';
+import { InjectRepository } from '../shims/typeorm';
 import { Repository } from 'typeorm';
 import type { paths } from '@contracts/api';
 import { TableThemeEntity } from '../database/entities/table-theme.entity';

--- a/backend/src/services/translations.service.ts
+++ b/backend/src/services/translations.service.ts
@@ -1,5 +1,5 @@
 import { Inject, Injectable } from '@nestjs/common';
-import { InjectRepository } from '@nestjs/typeorm';
+import { InjectRepository } from '../shims/typeorm';
 import { CACHE_MANAGER } from '@nestjs/cache-manager';
 import type { Cache } from 'cache-manager';
 import { Repository } from 'typeorm';

--- a/backend/src/shims/typeorm.ts
+++ b/backend/src/shims/typeorm.ts
@@ -1,0 +1,11 @@
+import './crypto';
+
+export {
+  InjectRepository,
+  TypeOrmModule,
+  getDataSourceToken,
+  getEntityManagerToken,
+  getRepositoryToken,
+} from '@nestjs/typeorm';
+
+export * from '@nestjs/typeorm';

--- a/backend/src/test-support/test-support.module.ts
+++ b/backend/src/test-support/test-support.module.ts
@@ -1,5 +1,5 @@
 import { Module } from '@nestjs/common';
-import { TypeOrmModule } from '@nestjs/typeorm';
+import { TypeOrmModule } from '../shims/typeorm';
 import { TestSupportController } from './test-support.controller';
 import { TestSupportService } from './test-support.service';
 import { User } from '../database/entities/user.entity';

--- a/backend/src/test-support/test-support.service.ts
+++ b/backend/src/test-support/test-support.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { InjectRepository } from '@nestjs/typeorm';
+import { InjectRepository } from '../shims/typeorm';
 import { Repository } from 'typeorm';
 import * as bcrypt from 'bcrypt';
 import { randomUUID } from 'crypto';

--- a/backend/src/tiers/tiers.module.ts
+++ b/backend/src/tiers/tiers.module.ts
@@ -1,5 +1,5 @@
 import { Module } from '@nestjs/common';
-import { TypeOrmModule } from '@nestjs/typeorm';
+import { TypeOrmModule } from '../shims/typeorm';
 import { Tier } from '../database/entities/tier.entity';
 import { TierRepository } from './tier.repository';
 import { TierService } from './tier.service';

--- a/backend/src/tournament/table-balancer.service.ts
+++ b/backend/src/tournament/table-balancer.service.ts
@@ -1,6 +1,6 @@
 import { Inject, Injectable, Optional } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import { InjectRepository } from '@nestjs/typeorm';
+import { InjectRepository } from '../shims/typeorm';
 import type Redis from 'ioredis';
 import { Repository } from 'typeorm';
 import { Table } from '../database/entities/table.entity';

--- a/backend/src/tournament/tournament.module.ts
+++ b/backend/src/tournament/tournament.module.ts
@@ -1,5 +1,5 @@
 import { Module } from '@nestjs/common';
-import { TypeOrmModule } from '@nestjs/typeorm';
+import { TypeOrmModule } from '../shims/typeorm';
 import { TournamentController } from './tournament.controller';
 import { AdminTournamentsController } from '../routes/admin-tournaments.controller';
 import { TournamentService } from './tournament.service';

--- a/backend/src/tournament/tournament.service.ts
+++ b/backend/src/tournament/tournament.service.ts
@@ -1,5 +1,5 @@
 import { Inject, Injectable, Optional, OnModuleInit } from '@nestjs/common';
-import { InjectRepository } from '@nestjs/typeorm';
+import { InjectRepository } from '../shims/typeorm';
 import type Redis from 'ioredis';
 import { saveRecentlyMoved } from './redis.util';
 import { Repository } from 'typeorm';

--- a/backend/src/users/users.module.ts
+++ b/backend/src/users/users.module.ts
@@ -1,5 +1,5 @@
 import { Module } from '@nestjs/common';
-import { TypeOrmModule } from '@nestjs/typeorm';
+import { TypeOrmModule } from '../shims/typeorm';
 import { UsersController } from '../routes/users.controller';
 import { AdminUsersController } from '../routes/admin-users.controller';
 import { ProfileController } from '../routes/profile.controller';

--- a/backend/src/wallet/bank-reconciliation.service.ts
+++ b/backend/src/wallet/bank-reconciliation.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { InjectRepository } from '@nestjs/typeorm';
+import { InjectRepository } from '../shims/typeorm';
 import { Repository } from 'typeorm';
 import { PendingDeposit } from './pending-deposit.entity';
 import { WalletService } from './wallet.service';

--- a/backend/src/wallet/revenue.service.ts
+++ b/backend/src/wallet/revenue.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import { InjectRepository } from '@nestjs/typeorm';
+import { InjectRepository } from '../shims/typeorm';
 import { Repository } from 'typeorm';
 import { Transaction } from './transaction.entity';
 import type { RevenueBreakdown } from '@shared/types';

--- a/backend/src/wallet/settlement.service.ts
+++ b/backend/src/wallet/settlement.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { InjectRepository } from '@nestjs/typeorm';
+import { InjectRepository } from '../shims/typeorm';
 import { Repository } from 'typeorm';
 import { randomUUID } from 'crypto';
 import { SettlementJournal } from './settlement-journal.entity';

--- a/backend/src/wallet/transactions.service.ts
+++ b/backend/src/wallet/transactions.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { InjectRepository } from '@nestjs/typeorm';
+import { InjectRepository } from '../shims/typeorm';
 import { Repository } from 'typeorm';
 import { z } from 'zod';
 import { TransactionType } from './transaction-type.entity';

--- a/backend/src/wallet/wallet.module.ts
+++ b/backend/src/wallet/wallet.module.ts
@@ -1,5 +1,5 @@
 import { Module, Injectable, OnModuleInit, forwardRef } from '@nestjs/common';
-import { TypeOrmModule } from '@nestjs/typeorm';
+import { TypeOrmModule } from '../shims/typeorm';
 import { Account } from './account.entity';
 import { JournalEntry } from './journal-entry.entity';
 import { Disbursement } from './disbursement.entity';

--- a/backend/src/wallet/wallet.service.ts
+++ b/backend/src/wallet/wallet.service.ts
@@ -1,6 +1,6 @@
 import { Inject, Injectable, ForbiddenException, Optional } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import { InjectRepository } from '@nestjs/typeorm';
+import { InjectRepository } from '../shims/typeorm';
 import { Repository, In, LessThan } from 'typeorm';
 import { createHash, randomUUID } from 'crypto';
 import { Account } from './account.entity';

--- a/backend/src/withdrawals/withdrawals.module.ts
+++ b/backend/src/withdrawals/withdrawals.module.ts
@@ -1,5 +1,5 @@
 import { Module } from '@nestjs/common';
-import { TypeOrmModule } from '@nestjs/typeorm';
+import { TypeOrmModule } from '../shims/typeorm';
 import { WithdrawalsController } from './withdrawals.controller';
 import { WithdrawalsService } from './withdrawals.service';
 import { WithdrawalDecision } from './withdrawal-decision.entity';

--- a/backend/src/withdrawals/withdrawals.service.ts
+++ b/backend/src/withdrawals/withdrawals.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { InjectRepository } from '@nestjs/typeorm';
+import { InjectRepository } from '../shims/typeorm';
 import { Repository } from 'typeorm';
 import { WithdrawalDecision } from './withdrawal-decision.entity';
 import { WalletService } from '../wallet/wallet.service';


### PR DESCRIPTION
## Summary
- add a backend TypeORM shim that preloads the crypto polyfill before delegating to @nestjs/typeorm
- update all modules and services to import TypeOrmModule and InjectRepository from the shim to avoid ReferenceError at startup

## Testing
- npm --prefix backend run build

------
https://chatgpt.com/codex/tasks/task_e_68d8db3910a8832387e97043df257860