### PR TITLE
fix: use typeorm shim in tests

### DIFF
--- a/backend/test/admin-blocked-countries.controller.spec.ts
+++ b/backend/test/admin-blocked-countries.controller.spec.ts
@@ -2,7 +2,7 @@ process.env.DATABASE_URL = '';
 
 import { Test, TestingModule } from '@nestjs/testing';
 import { INestApplication } from '@nestjs/common';
-import { TypeOrmModule } from '@nestjs/typeorm';
+import { TypeOrmModule } from '../src/shims/typeorm';
 import { DataSource } from 'typeorm';
 import { DataType, newDb } from 'pg-mem';
 import request from 'supertest';

--- a/backend/test/admin-bonus.controller.spec.ts
+++ b/backend/test/admin-bonus.controller.spec.ts
@@ -2,7 +2,7 @@ process.env.DATABASE_URL = '';
 
 import { Test, TestingModule } from '@nestjs/testing';
 import { INestApplication, Module } from '@nestjs/common';
-import { TypeOrmModule } from '@nestjs/typeorm';
+import { TypeOrmModule } from '../src/shims/typeorm';
 import { DataSource } from 'typeorm';
 import { ConfigService } from '@nestjs/config';
 import { randomUUID } from 'crypto';

--- a/backend/test/admin-bonuses.controller.spec.ts
+++ b/backend/test/admin-bonuses.controller.spec.ts
@@ -2,7 +2,7 @@ process.env.DATABASE_URL = '';
 
 import { Test, TestingModule } from '@nestjs/testing';
 import { INestApplication, Module } from '@nestjs/common';
-import { TypeOrmModule, getRepositoryToken } from '@nestjs/typeorm';
+import { TypeOrmModule, getRepositoryToken } from '../src/shims/typeorm';
 import { ConfigService } from '@nestjs/config';
 import { DataSource } from 'typeorm';
 import { DataType, newDb } from 'pg-mem';

--- a/backend/test/admin-messages.integration.spec.ts
+++ b/backend/test/admin-messages.integration.spec.ts
@@ -2,7 +2,7 @@ process.env.DATABASE_URL = '';
 
 import { Test, TestingModule } from '@nestjs/testing';
 import type { INestApplication } from '@nestjs/common';
-import { TypeOrmModule } from '@nestjs/typeorm';
+import { TypeOrmModule } from '../src/shims/typeorm';
 import { DataSource } from 'typeorm';
 import { DataType, newDb } from 'pg-mem';
 import request from 'supertest';

--- a/backend/test/admin-tournaments.controller.spec.ts
+++ b/backend/test/admin-tournaments.controller.spec.ts
@@ -3,7 +3,7 @@ process.env.DATABASE_URL = '';
 import { Test } from '@nestjs/testing';
 import type { INestApplication } from '@nestjs/common';
 import request from 'supertest';
-import { TypeOrmModule, getRepositoryToken } from '@nestjs/typeorm';
+import { TypeOrmModule, getRepositoryToken } from '../src/shims/typeorm';
 import { DataSource, Repository } from 'typeorm';
 import { DataType, newDb } from 'pg-mem';
 import { AdminTournamentsController } from '../src/routes/admin-tournaments.controller';

--- a/backend/test/admin.tabs.integration.spec.ts
+++ b/backend/test/admin.tabs.integration.spec.ts
@@ -2,7 +2,7 @@ process.env.DATABASE_URL = '';
 
 import { Test } from '@nestjs/testing';
 import type { INestApplication } from '@nestjs/common';
-import { TypeOrmModule } from '@nestjs/typeorm';
+import { TypeOrmModule } from '../src/shims/typeorm';
 import { DataSource } from 'typeorm';
 import { DataType, newDb } from 'pg-mem';
 import request from 'supertest';

--- a/backend/test/analytics/review.controller.spec.ts
+++ b/backend/test/analytics/review.controller.spec.ts
@@ -9,7 +9,7 @@ import { AdminGuard } from '../../src/auth/admin.guard';
 import { createInMemoryRedis } from '../utils/mock-redis';
 import { DataSource } from 'typeorm';
 import { DataType, newDb } from 'pg-mem';
-import { getRepositoryToken } from '@nestjs/typeorm';
+import { getRepositoryToken } from '../../src/shims/typeorm';
 import { CollusionAudit } from '../../src/analytics/collusion-audit.entity';
 
 describe('ReviewController', () => {

--- a/backend/test/bonus.service.spec.ts
+++ b/backend/test/bonus.service.spec.ts
@@ -2,7 +2,7 @@ process.env.DATABASE_URL = '';
 
 import { Test, TestingModule } from '@nestjs/testing';
 import { Module } from '@nestjs/common';
-import { TypeOrmModule } from '@nestjs/typeorm';
+import { TypeOrmModule } from '../src/shims/typeorm';
 import { DataSource, Repository } from 'typeorm';
 import { ConfigService } from '@nestjs/config';
 import { randomUUID } from 'crypto';

--- a/backend/test/config.controller.spec.ts
+++ b/backend/test/config.controller.spec.ts
@@ -5,7 +5,7 @@ process.env.PERF_THRESHOLD_CLS = '0.1';
 
 import { Test, TestingModule } from '@nestjs/testing';
 import { INestApplication, Module } from '@nestjs/common';
-import { TypeOrmModule } from '@nestjs/typeorm';
+import { TypeOrmModule } from '../src/shims/typeorm';
 import { DataSource } from 'typeorm';
 import { DataType, newDb } from 'pg-mem';
 import request from 'supertest';

--- a/backend/test/contracts/history-tabs.contract.spec.ts
+++ b/backend/test/contracts/history-tabs.contract.spec.ts
@@ -2,7 +2,7 @@ process.env.DATABASE_URL = '';
 
 import { INestApplication } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
-import { TypeOrmModule } from '@nestjs/typeorm';
+import { TypeOrmModule } from '../../src/shims/typeorm';
 import { DataSource } from 'typeorm';
 import { DataType, newDb } from 'pg-mem';
 import request from 'supertest';

--- a/backend/test/game.gateway.auth.spec.ts
+++ b/backend/test/game.gateway.auth.spec.ts
@@ -10,7 +10,7 @@ import { GameGateway } from '../src/game/game.gateway';
 import { ClockService } from '../src/game/clock.service';
 import { AnalyticsService } from '../src/analytics/analytics.service';
 import { RoomManager } from '../src/game/room.service';
-import { getRepositoryToken } from '@nestjs/typeorm';
+import { getRepositoryToken } from '../src/shims/typeorm';
 import { Hand } from '../src/database/entities/hand.entity';
 import { GameState } from '../src/database/entities/game-state.entity';
 

--- a/backend/test/game.gateway.idempotency.spec.ts
+++ b/backend/test/game.gateway.idempotency.spec.ts
@@ -4,7 +4,7 @@ import { ClockService } from '../src/game/clock.service';
 import { AnalyticsService } from '../src/analytics/analytics.service';
 import { EventPublisher } from '../src/events/events.service';
 import { RoomManager } from '../src/game/room.service';
-import { getRepositoryToken } from '@nestjs/typeorm';
+import { getRepositoryToken } from '../src/shims/typeorm';
 import { Hand } from '../src/database/entities/hand.entity';
 import { GameState } from '../src/database/entities/game-state.entity';
 import { createInMemoryRedis, MockRedis } from './utils/mock-redis';

--- a/backend/test/game/disconnect.spec.ts
+++ b/backend/test/game/disconnect.spec.ts
@@ -3,7 +3,7 @@ import { GameGateway } from '../../src/game/game.gateway';
 import { ClockService } from '../../src/game/clock.service';
 import { AnalyticsService } from '../../src/analytics/analytics.service';
 import { EventPublisher } from '../../src/events/events.service';
-import { getRepositoryToken } from '@nestjs/typeorm';
+import { getRepositoryToken } from '../../src/shims/typeorm';
 import { Hand } from '../../src/database/entities/hand.entity';
 import { RoomManager } from '../../src/game/room.service';
 import { EventEmitter } from 'events';

--- a/backend/test/game/duplicate-action.spec.ts
+++ b/backend/test/game/duplicate-action.spec.ts
@@ -4,7 +4,7 @@ import { GameGateway } from '../../src/game/game.gateway';
 import { ClockService } from '../../src/game/clock.service';
 import { AnalyticsService } from '../../src/analytics/analytics.service';
 import { EventPublisher } from '../../src/events/events.service';
-import { getRepositoryToken } from '@nestjs/typeorm';
+import { getRepositoryToken } from '../../src/shims/typeorm';
 import { Hand } from '../../src/database/entities/hand.entity';
 import { GameState } from '../../src/database/entities/game-state.entity';
 import { RoomManager } from '../../src/game/room.service';

--- a/backend/test/game/frame-ack.spec.ts
+++ b/backend/test/game/frame-ack.spec.ts
@@ -21,7 +21,7 @@ import { RoomManager } from '../../src/game/room.service';
 import { ClockService } from '../../src/game/clock.service';
 import { AnalyticsService } from '../../src/analytics/analytics.service';
 import { EventPublisher } from '../../src/events/events.service';
-import { getRepositoryToken } from '@nestjs/typeorm';
+import { getRepositoryToken } from '../../src/shims/typeorm';
 import { Hand } from '../../src/database/entities/hand.entity';
 import { createInMemoryRedis } from '../utils/mock-redis';
 import { GameState } from '../../src/database/entities/game-state.entity';

--- a/backend/test/game/gateway-engine.spec.ts
+++ b/backend/test/game/gateway-engine.spec.ts
@@ -14,7 +14,7 @@ jest.mock('../../src/game/pqueue-loader', () => {
 });
 import { GameGateway } from '../../src/game/game.gateway';
 import { AnalyticsService } from '../../src/analytics/analytics.service';
-import { getRepositoryToken } from '@nestjs/typeorm';
+import { getRepositoryToken } from '../../src/shims/typeorm';
 import { Hand } from '../../src/database/entities/hand.entity';
 import { GameState } from '../../src/database/entities/game-state.entity';
 import { RoomManager } from '../../src/game/room.service';

--- a/backend/test/game/gateway-privacy.spec.ts
+++ b/backend/test/game/gateway-privacy.spec.ts
@@ -6,7 +6,7 @@ import { RoomManager } from '../../src/game/room.service';
 import { ClockService } from '../../src/game/clock.service';
 import { AnalyticsService } from '../../src/analytics/analytics.service';
 import { EventPublisher } from '../../src/events/events.service';
-import { getRepositoryToken } from '@nestjs/typeorm';
+import { getRepositoryToken } from '../../src/shims/typeorm';
 import { Hand } from '../../src/database/entities/hand.entity';
 import { createInMemoryRedis } from '../utils/mock-redis';
 import { GameState } from '../../src/database/entities/game-state.entity';

--- a/backend/test/game/hand.controller.spec.ts
+++ b/backend/test/game/hand.controller.spec.ts
@@ -1,6 +1,6 @@
 import { Test } from '@nestjs/testing';
 import { INestApplication } from '@nestjs/common';
-import { getRepositoryToken } from '@nestjs/typeorm';
+import { getRepositoryToken } from '../../src/shims/typeorm';
 import { existsSync, unlinkSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import request from 'supertest';

--- a/backend/test/game/reconnect.spec.ts
+++ b/backend/test/game/reconnect.spec.ts
@@ -21,7 +21,7 @@ import { RoomManager } from '../../src/game/room.service';
 import { ClockService } from '../../src/game/clock.service';
 import { AnalyticsService } from '../../src/analytics/analytics.service';
 import { EventPublisher } from '../../src/events/events.service';
-import { getRepositoryToken } from '@nestjs/typeorm';
+import { getRepositoryToken } from '../../src/shims/typeorm';
 import { Hand } from '../../src/database/entities/hand.entity';
 import { createInMemoryRedis } from '../utils/mock-redis';
 import { GameState } from '../../src/database/entities/game-state.entity';

--- a/backend/test/game/restart.spec.ts
+++ b/backend/test/game/restart.spec.ts
@@ -7,7 +7,7 @@ import { ClockService } from '../../src/game/clock.service';
 import { AnalyticsService } from '../../src/analytics/analytics.service';
 import { EventPublisher } from '../../src/events/events.service';
 import { createInMemoryRedis, MockRedis } from '../utils/mock-redis';
-import { getRepositoryToken } from '@nestjs/typeorm';
+import { getRepositoryToken } from '../../src/shims/typeorm';
 import { Hand } from '../../src/database/entities/hand.entity';
 import { GameState } from '../../src/database/entities/game-state.entity';
 

--- a/backend/test/game/spectator.privacy.spec.ts
+++ b/backend/test/game/spectator.privacy.spec.ts
@@ -7,7 +7,7 @@ import { SpectatorGateway } from '../../src/game/spectator.gateway';
 import { RoomManager } from '../../src/game/room.service';
 import { ClockService } from '../../src/game/clock.service';
 import { AnalyticsService } from '../../src/analytics/analytics.service';
-import { getRepositoryToken } from '@nestjs/typeorm';
+import { getRepositoryToken } from '../../src/shims/typeorm';
 import { Hand } from '../../src/database/entities/hand.entity';
 import { GameEngine, GameAction } from '../../src/game/engine';
 import { createInMemoryRedis } from '../utils/mock-redis';

--- a/backend/test/game/state-recovery.spec.ts
+++ b/backend/test/game/state-recovery.spec.ts
@@ -3,7 +3,7 @@ import { GameGateway } from '../../src/game/game.gateway';
 import { ClockService } from '../../src/game/clock.service';
 import { AnalyticsService } from '../../src/analytics/analytics.service';
 import { RoomManager } from '../../src/game/room.service';
-import { getRepositoryToken } from '@nestjs/typeorm';
+import { getRepositoryToken } from '../../src/shims/typeorm';
 import { Hand } from '../../src/database/entities/hand.entity';
 import { GameState } from '../../src/database/entities/game-state.entity';
 import { createInMemoryRedis } from '../utils/mock-redis';

--- a/backend/test/game/timeout.spec.ts
+++ b/backend/test/game/timeout.spec.ts
@@ -4,7 +4,7 @@ import { ClockService } from '../../src/game/clock.service';
 import { RoomManager } from '../../src/game/room.service';
 import { AnalyticsService } from '../../src/analytics/analytics.service';
 import { EventPublisher } from '../../src/events/events.service';
-import { getRepositoryToken } from '@nestjs/typeorm';
+import { getRepositoryToken } from '../../src/shims/typeorm';
 import { Hand } from '../../src/database/entities/hand.entity';
 import { createInMemoryRedis } from '../utils/mock-redis';
 import { ConfigService } from '@nestjs/config';

--- a/backend/test/hands/hand-test-utils.ts
+++ b/backend/test/hands/hand-test-utils.ts
@@ -1,6 +1,6 @@
 import { Test } from '@nestjs/testing';
 import { INestApplication } from '@nestjs/common';
-import { getRepositoryToken } from '@nestjs/typeorm';
+import { getRepositoryToken } from '../../src/shims/typeorm';
 import { ConfigService } from '@nestjs/config';
 import jwt from 'jsonwebtoken';
 import { existsSync, mkdirSync, unlinkSync, writeFileSync } from 'fs';

--- a/backend/test/hands/log.spec.ts
+++ b/backend/test/hands/log.spec.ts
@@ -1,6 +1,6 @@
 import { Test } from '@nestjs/testing';
 import { INestApplication } from '@nestjs/common';
-import { getRepositoryToken } from '@nestjs/typeorm';
+import { getRepositoryToken } from '../../src/shims/typeorm';
 import request from 'supertest';
 import jwt from 'jsonwebtoken';
 import { HandController } from '../../src/game/hand.controller';

--- a/backend/test/hands/proof.spec.ts
+++ b/backend/test/hands/proof.spec.ts
@@ -1,6 +1,6 @@
 import { Test } from '@nestjs/testing';
 import { INestApplication } from '@nestjs/common';
-import { getRepositoryToken } from '@nestjs/typeorm';
+import { getRepositoryToken } from '../../src/shims/typeorm';
 import jwt from 'jsonwebtoken';
 import { ConfigService } from '@nestjs/config';
 import { HandController } from '../../src/game/hand.controller';

--- a/backend/test/hands/proofs.spec.ts
+++ b/backend/test/hands/proofs.spec.ts
@@ -1,6 +1,6 @@
 import { Test } from '@nestjs/testing';
 import { INestApplication } from '@nestjs/common';
-import { getRepositoryToken } from '@nestjs/typeorm';
+import { getRepositoryToken } from '../../src/shims/typeorm';
 import jwt from 'jsonwebtoken';
 import request from 'supertest';
 import { ConfigService } from '@nestjs/config';

--- a/backend/test/hands/public-proof.spec.ts
+++ b/backend/test/hands/public-proof.spec.ts
@@ -1,6 +1,6 @@
 import { Test } from '@nestjs/testing';
 import { INestApplication } from '@nestjs/common';
-import { getRepositoryToken } from '@nestjs/typeorm';
+import { getRepositoryToken } from '../../src/shims/typeorm';
 import request from 'supertest';
 import { Hand } from '../../src/database/entities/hand.entity';
 import { HandsController } from '../../src/routes/hands.controller';

--- a/backend/test/history-tabs.controller.spec.ts
+++ b/backend/test/history-tabs.controller.spec.ts
@@ -2,7 +2,7 @@ process.env.DATABASE_URL = '';
 
 import { INestApplication } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
-import { TypeOrmModule } from '@nestjs/typeorm';
+import { TypeOrmModule } from '../src/shims/typeorm';
 import { DataSource } from 'typeorm';
 import { DataType, newDb } from 'pg-mem';
 import request from 'supertest';

--- a/backend/test/history/history.controller.spec.ts
+++ b/backend/test/history/history.controller.spec.ts
@@ -1,7 +1,7 @@
 import { Test } from '@nestjs/testing';
 import { INestApplication } from '@nestjs/common';
 import request from 'supertest';
-import { TypeOrmModule } from '@nestjs/typeorm';
+import { TypeOrmModule } from '../../src/shims/typeorm';
 import { DataType, newDb } from 'pg-mem';
 import { AuthGuard } from '../../src/auth/auth.guard';
 import {

--- a/backend/test/languages.controller.spec.ts
+++ b/backend/test/languages.controller.spec.ts
@@ -2,7 +2,7 @@ process.env.DATABASE_URL = '';
 
 import { Test, TestingModule } from '@nestjs/testing';
 import { INestApplication } from '@nestjs/common';
-import { TypeOrmModule } from '@nestjs/typeorm';
+import { TypeOrmModule } from '../src/shims/typeorm';
 import { DataSource } from 'typeorm';
 import { DataType, newDb } from 'pg-mem';
 import request from 'supertest';

--- a/backend/test/me.controller.spec.ts
+++ b/backend/test/me.controller.spec.ts
@@ -2,7 +2,7 @@ process.env.JWT_SECRET = 'secret';
 
 import { Test, TestingModule } from '@nestjs/testing';
 import { INestApplication, ExecutionContext, Module } from '@nestjs/common';
-import { TypeOrmModule } from '@nestjs/typeorm';
+import { TypeOrmModule } from '../src/shims/typeorm';
 import { DataSource } from 'typeorm';
 import request from 'supertest';
 import { createDataSource, destroyDataSource } from './utils/pgMem';

--- a/backend/test/nav-icons.controller.spec.ts
+++ b/backend/test/nav-icons.controller.spec.ts
@@ -2,7 +2,7 @@ process.env.DATABASE_URL = '';
 
 import { Test, TestingModule } from '@nestjs/testing';
 import { INestApplication } from '@nestjs/common';
-import { TypeOrmModule } from '@nestjs/typeorm';
+import { TypeOrmModule } from '../src/shims/typeorm';
 import { DataSource } from 'typeorm';
 import { DataType, newDb } from 'pg-mem';
 import request from 'supertest';

--- a/backend/test/nav-items.controller.spec.ts
+++ b/backend/test/nav-items.controller.spec.ts
@@ -2,7 +2,7 @@ process.env.DATABASE_URL = '';
 
 import { Test, TestingModule } from '@nestjs/testing';
 import { INestApplication } from '@nestjs/common';
-import { TypeOrmModule } from '@nestjs/typeorm';
+import { TypeOrmModule } from '../src/shims/typeorm';
 import { DataSource } from 'typeorm';
 import { DataType, newDb } from 'pg-mem';
 import request from 'supertest';

--- a/backend/test/notifications.controller.spec.ts
+++ b/backend/test/notifications.controller.spec.ts
@@ -4,7 +4,7 @@ process.env.JWT_SECRET = 'secret';
 
 import { Test } from '@nestjs/testing';
 import type { INestApplication, ExecutionContext } from '@nestjs/common';
-import { TypeOrmModule } from '@nestjs/typeorm';
+import { TypeOrmModule } from '../src/shims/typeorm';
 import { ConfigModule } from '@nestjs/config';
 import { DataSource } from 'typeorm';
 import { DataType, newDb } from 'pg-mem';
@@ -12,7 +12,7 @@ import request from 'supertest';
 import { NotificationsModule } from '../src/notifications/notifications.module';
 import { Notification } from '../src/notifications/notification.entity';
 import { AuthGuard } from '../src/auth/auth.guard';
-import { getRepositoryToken } from '@nestjs/typeorm';
+import { getRepositoryToken } from '../src/shims/typeorm';
 import type { Repository } from 'typeorm';
 import { API_CONTRACT_VERSION } from '@shared/constants';
 

--- a/backend/test/profile.controller.spec.ts
+++ b/backend/test/profile.controller.spec.ts
@@ -12,7 +12,7 @@ import { webcrypto } from 'crypto';
 
 import { Test, TestingModule } from '@nestjs/testing';
 import { INestApplication, ExecutionContext, Module } from '@nestjs/common';
-import { TypeOrmModule } from '@nestjs/typeorm';
+import { TypeOrmModule } from '../src/shims/typeorm';
 import { DataSource } from 'typeorm';
 import { createDataSource, destroyDataSource } from './utils/pgMem';
 import request from 'supertest';

--- a/backend/test/promotions.service.spec.ts
+++ b/backend/test/promotions.service.spec.ts
@@ -2,7 +2,7 @@ process.env.DATABASE_URL = '';
 
 import { Module, ConflictException, NotFoundException, INestApplication } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
-import { TypeOrmModule } from '@nestjs/typeorm';
+import { TypeOrmModule } from '../src/shims/typeorm';
 import { DataSource } from 'typeorm';
 import { DataType, newDb } from 'pg-mem';
 import { PromotionsService } from '../src/promotions/promotions.service';

--- a/backend/test/scoped-feature-flags.spec.ts
+++ b/backend/test/scoped-feature-flags.spec.ts
@@ -10,7 +10,7 @@ import { GameGateway } from '../src/game/game.gateway';
 import { ClockService } from '../src/game/clock.service';
 import { AnalyticsService } from '../src/analytics/analytics.service';
 import { EventPublisher } from '../src/events/events.service';
-import { getRepositoryToken } from '@nestjs/typeorm';
+import { getRepositoryToken } from '../src/shims/typeorm';
 import { Hand } from '../src/database/entities/hand.entity';
 import { GameState } from '../src/database/entities/game-state.entity';
 import { RoomManager } from '../src/game/room.service';

--- a/backend/test/settings.integration.spec.ts
+++ b/backend/test/settings.integration.spec.ts
@@ -2,7 +2,7 @@ process.env.DATABASE_URL = '';
 
 import { Test, TestingModule } from '@nestjs/testing';
 import type { INestApplication } from '@nestjs/common';
-import { TypeOrmModule } from '@nestjs/typeorm';
+import { TypeOrmModule } from '../src/shims/typeorm';
 import { DataSource } from 'typeorm';
 import { DataType, newDb } from 'pg-mem';
 import request from 'supertest';

--- a/backend/test/tables/list.spec.ts
+++ b/backend/test/tables/list.spec.ts
@@ -2,7 +2,7 @@ process.env.DATABASE_URL = '';
 
 import { Test, TestingModule } from '@nestjs/testing';
 import { INestApplication, Module } from '@nestjs/common';
-import { TypeOrmModule } from '@nestjs/typeorm';
+import { TypeOrmModule } from '../../src/shims/typeorm';
 import { DataSource } from 'typeorm';
 import { DataType, newDb } from 'pg-mem';
 import request from 'supertest';

--- a/backend/test/tables/tabs.integration.spec.ts
+++ b/backend/test/tables/tabs.integration.spec.ts
@@ -2,7 +2,7 @@ process.env.DATABASE_URL = '';
 
 import { Test, TestingModule } from '@nestjs/testing';
 import { INestApplication, Module } from '@nestjs/common';
-import { TypeOrmModule, getRepositoryToken } from '@nestjs/typeorm';
+import { TypeOrmModule, getRepositoryToken } from '../../src/shims/typeorm';
 import { DataSource } from 'typeorm';
 import { DataType, newDb } from 'pg-mem';
 import request from 'supertest';

--- a/backend/test/tiers.controller.spec.ts
+++ b/backend/test/tiers.controller.spec.ts
@@ -2,7 +2,7 @@ process.env.DATABASE_URL = '';
 
 import { Test, TestingModule } from '@nestjs/testing';
 import { INestApplication, Module } from '@nestjs/common';
-import { TypeOrmModule } from '@nestjs/typeorm';
+import { TypeOrmModule } from '../src/shims/typeorm';
 import { DataSource } from 'typeorm';
 import { DataType, newDb } from 'pg-mem';
 import request from 'supertest';

--- a/backend/test/transactions.controller.spec.ts
+++ b/backend/test/transactions.controller.spec.ts
@@ -4,7 +4,7 @@ import request from 'supertest';
 import { TransactionsController } from '../src/routes/transactions.controller';
 import { AuthGuard } from '../src/auth/auth.guard';
 import { AdminGuard } from '../src/auth/admin.guard';
-import { TypeOrmModule, getRepositoryToken } from '@nestjs/typeorm';
+import { TypeOrmModule, getRepositoryToken } from '../src/shims/typeorm';
 import { TransactionsService } from '../src/wallet/transactions.service';
 import { TransactionType } from '../src/wallet/transaction-type.entity';
 import { Transaction } from '../src/wallet/transaction.entity';

--- a/backend/test/transactions.service.spec.ts
+++ b/backend/test/transactions.service.spec.ts
@@ -1,5 +1,5 @@
 import { Test } from '@nestjs/testing';
-import { TypeOrmModule, getRepositoryToken } from '@nestjs/typeorm';
+import { TypeOrmModule, getRepositoryToken } from '../src/shims/typeorm';
 import { DataSource, Repository } from 'typeorm';
 import { DataType, newDb } from 'pg-mem';
 import { TransactionsService } from '../src/wallet/transactions.service';

--- a/backend/test/translations.controller.spec.ts
+++ b/backend/test/translations.controller.spec.ts
@@ -3,7 +3,7 @@ process.env.DATABASE_URL = '';
 import { Test, TestingModule } from '@nestjs/testing';
 import { INestApplication } from '@nestjs/common';
 import { CacheModule } from '@nestjs/cache-manager';
-import { TypeOrmModule } from '@nestjs/typeorm';
+import { TypeOrmModule } from '../src/shims/typeorm';
 import { DataSource } from 'typeorm';
 import { DataType, newDb } from 'pg-mem';
 import request from 'supertest';

--- a/backend/test/users.spec.ts
+++ b/backend/test/users.spec.ts
@@ -9,7 +9,7 @@ process.env.JWT_SECRET = 'secret';
 
 import { Test, TestingModule } from '@nestjs/testing';
 import { INestApplication, Module, ExecutionContext } from '@nestjs/common';
-import { TypeOrmModule } from '@nestjs/typeorm';
+import { TypeOrmModule } from '../src/shims/typeorm';
 import { DataSource } from 'typeorm';
 import { DataType, newDb } from 'pg-mem';
 import request from 'supertest';

--- a/backend/test/utils/createTournamentModule.ts
+++ b/backend/test/utils/createTournamentModule.ts
@@ -1,5 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { getRepositoryToken } from '@nestjs/typeorm';
+import { getRepositoryToken } from '../../src/shims/typeorm';
 import { TournamentService } from '../../src/tournament/tournament.service';
 import { Tournament } from '../../src/database/entities/tournament.entity';
 import { Seat } from '../../src/database/entities/seat.entity';

--- a/backend/test/wallet/settlement.service.spec.ts
+++ b/backend/test/wallet/settlement.service.spec.ts
@@ -1,5 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { TypeOrmModule, getRepositoryToken } from '@nestjs/typeorm';
+import { TypeOrmModule, getRepositoryToken } from '../../src/shims/typeorm';
 import { Repository, DataSource } from 'typeorm';
 import { createInMemoryDb } from './test-utils';
 import { SettlementJournal } from '../../src/wallet/settlement-journal.entity';

--- a/frontend/e2e/utils/gameGatewaySetup.ts
+++ b/frontend/e2e/utils/gameGatewaySetup.ts
@@ -6,7 +6,7 @@ import { RoomManager } from '../../../backend/src/game/room.service';
 import { ClockService } from '../../../backend/src/game/clock.service';
 import { AnalyticsService } from '../../../backend/src/analytics/analytics.service';
 import { EventPublisher } from '../../../backend/src/events/events.service';
-import { getRepositoryToken } from '../../../backend/node_modules/@nestjs/typeorm';
+import { getRepositoryToken } from '../../../backend/src/shims/typeorm';
 import { Hand } from '../../../backend/src/database/entities/hand.entity';
 
 interface Options {


### PR DESCRIPTION
## Summary
- update backend tests to import Nest's TypeORM helpers through the local shim so the crypto polyfill runs first
- point the frontend e2e game gateway helper at the shimmed getRepositoryToken export

## Testing
- npm --prefix backend run test -- --runTestsByPath test/bonus.service.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68d8e3d2d8a08323a2633129aac2bee3