### PR TITLE
fix: honor backend-specific port override

### DIFF
--- a/backend/src/config/env.validation.ts
+++ b/backend/src/config/env.validation.ts
@@ -25,6 +25,7 @@ export const validationSchema = Joi.object({
   OTEL_EXPORTER_PROMETHEUS_ENDPOINT: Joi.string().optional(),
   OTEL_SERVICE_NAME: Joi.string().optional(),
   LOG_PROVIDER: Joi.string().optional(),
+  BACKEND_PORT: Joi.number().integer().optional(),
   PORT: Joi.number().integer().optional(),
   JWT_SECRETS: Joi.string().default('dev-secret'),
   JWT_ACCESS_TTL: Joi.number().integer().optional(),

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -18,7 +18,8 @@ async function main() {
   const document = SwaggerModule.createDocument(app, config);
   SwaggerModule.setup('docs', app, document);
 
-  await app.listen(process.env.PORT ?? 3000);
+  const port = process.env.BACKEND_PORT ?? process.env.PORT ?? 3000;
+  await app.listen(port);
   scheduleReconcileJob(
     app.get(WalletService),
     app.get(Logger),


### PR DESCRIPTION
## Summary
- allow the Nest bootstrapper to prefer BACKEND_PORT over PORT before falling back to 3000
- extend the environment validation schema so BACKEND_PORT is exposed through the ConfigService

## Testing
- BACKEND_PORT=4010 npm run start:dev
- curl -s -o /dev/null -w "%{http_code}" http://localhost:4010/status


------
https://chatgpt.com/codex/tasks/task_e_68d8e4efce188323993edb509f2f6647