### PR TITLE
chore: align backend Docker build context with repository root

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -39,7 +39,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Build backend image
-      run: docker build -t backend ./backend
+      run: docker build -t backend -f backend/Dockerfile .
     - name: Scan backend image
       uses: aquasecurity/trivy-action@0.33.0
       with:

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,8 +1,13 @@
 FROM node:20-alpine
 WORKDIR /app
-COPY package*.json ./
+
+COPY backend/package*.json ./
 RUN npm install
-COPY . .
+
+COPY backend/. .
+COPY shared ./shared
+COPY contracts ./contracts
+
 RUN npm run build
 ENV DB_SYNC=false
 CMD ["npm", "run", "start:prod"]

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -11,7 +11,9 @@ services:
       retries: 5
 
   backend:
-    build: ./backend
+    build:
+      context: .
+      dockerfile: backend/Dockerfile
     command: npm run start:dev
     environment:
       - REDIS_HOST=redis

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,9 @@ services:
       - backend
 
   backend:
-    build: ./backend
+    build:
+      context: .
+      dockerfile: backend/Dockerfile
     command: npm run start:dev
     env_file:
       - ./backend/.env


### PR DESCRIPTION
## Summary
- point backend service builds in docker-compose files to the repo root and use backend/Dockerfile
- adjust the backend Dockerfile to install from backend/, copy shared and contracts directories, and build successfully
- update the security scan workflow to build the backend image from the repository root

## Testing
- npm run build --prefix backend

------
https://chatgpt.com/codex/tasks/task_e_68d8eecadb9083239494114d84a5d012