### PR TITLE
Adjust backend Dockerfile paths for nested app structure

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,13 +1,16 @@
 FROM node:20-alpine
+
 WORKDIR /app
 
-COPY backend/package*.json ./
-RUN npm install
+COPY backend/package*.json backend/
+RUN npm ci --prefix backend
 
-COPY backend/. .
-COPY shared ./shared
-COPY contracts ./contracts
+COPY backend/ backend/
+COPY shared/ shared/
+COPY contracts/ contracts/
 
+WORKDIR /app/backend
 RUN npm run build
+
 ENV DB_SYNC=false
 CMD ["npm", "run", "start:prod"]


### PR DESCRIPTION
## Summary
- update backend Dockerfile to install dependencies into /app/backend and keep shared/contracts as siblings
- switch to npm ci with prefix and set workdir to /app/backend before build and runtime commands

## Testing
- docker compose build backend *(fails: command not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d8f0b6930883239083b84c48e433a4